### PR TITLE
Improve node exit handling

### DIFF
--- a/src/autonomous_kart/autonomous_kart/nodes/camera/camera_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/camera/camera_node.py
@@ -137,10 +137,8 @@ def main(args=None):
         node.running = False
         executor.shutdown(timeout_sec=1.0)
         node.destroy_node()
-        try:
+        if rclpy.ok():
             rclpy.shutdown()
-        except:
-            pass # Context already shutdown, ignore
 
 
 if __name__ == "__main__":

--- a/src/autonomous_kart/autonomous_kart/nodes/motor/motor_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/motor/motor_node.py
@@ -89,10 +89,8 @@ def main(args=None):
         node.get_logger().error('Unhandled exception', exc_info=True)
     finally:
         node.destroy_node()
-        try:
+        if rclpy.ok():
             rclpy.shutdown()
-        except:
-            pass # Context already shutdown, ignore
 
 
 if __name__ == '__main__':

--- a/src/autonomous_kart/autonomous_kart/nodes/opencv_pathfinder/opencv_pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/opencv_pathfinder/opencv_pathfinder_node.py
@@ -94,11 +94,8 @@ def main(args=None):
         node.running = False
         executor.shutdown(timeout_sec=1.0)
         node.destroy_node()
-        try:
+        if rclpy.ok():
             rclpy.shutdown()
-        except:
-            pass # Context already shutdown, ignore
-
 
 if __name__ == '__main__':
     main()

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -89,10 +89,8 @@ def main(args=None):
         node.get_logger().error('Unhandled exception', exc_info=True)
     finally:
         node.destroy_node()
-        try:
+        if rclpy.ok():
             rclpy.shutdown()
-        except:
-            pass # Context already shutdown, ignore
 
 
 if __name__ == '__main__':

--- a/src/autonomous_kart/autonomous_kart/nodes/steering/steering_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/steering/steering_node.py
@@ -89,10 +89,8 @@ def main(args=None):
         node.get_logger().error('Unhandled exception', exc_info=True)
     finally:
         node.destroy_node()
-        try:
+        if rclpy.ok():
             rclpy.shutdown()
-        except:
-            pass # Context already shutdown, ignore
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Differentiate based on error exit or control-c exit
- Only shutdown `rclpy` once
- Shutdown `rlcpy` on multithreaded node exit
- Multithreaded notes use ROS controlled timeout instead of `time.sleep()`