### PR TITLE
Smanor/pathfinder cleanup: cleanup pathfinder issues

### DIFF
--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -57,6 +57,10 @@ class PathfinderNode(Node):
         self.approach_dist_m = float(self.get_parameter("approach_dist_m").value)
         self.min_approach_speed_pct = float(self.get_parameter("min_approach_speed_pct").value)
 
+        self.search_window = int(self.get_parameter("search_window").value)
+        self.initial_sync_done = bool(self.get_parameter("initial_sync_done").value)
+        self.max_resync_dist = float(self.get_parameter("max_resync_dist").value)
+
         self.pose_ready = False
         # self.pose_ready = True  # Dummy until localization works
         self.current_xy = (0.0, 0.0)
@@ -66,17 +70,7 @@ class PathfinderNode(Node):
         self.localization_sub = self.create_subscription(Odometry, "odom", self.localization, 10)
 
         self.closest_idx = 0
-        # First autonomous tick after pose_ready does an O(n) full-line nearest
-        # search so spawning or re-posing anywhere on the track syncs correctly.
-        # Subsequent ticks use a bounded forward search.
-        self._initial_sync_done = False
-        # Bounded forward search window in waypoints.
-        self._search_window = 80
-        # If the kart's distance to racing_line[closest_idx] exceeds this
-        # threshold, the windowed search is presumed stale (localization jump,
-        # large off-track excursion) and we re-run the full-line search.
-        # 20 m is well beyond any normal CTE/waypoint spacing on the racing line.
-        self._resync_distance_m = 20.0
+
 
         self.metrics_publisher = self.create_publisher(
             Float32MultiArray, "pathfinder_params", 5
@@ -186,18 +180,18 @@ class PathfinderNode(Node):
             #   3. Normal operation: bounded forward search with wrap for the
             #      closed racing line.
             if self.racing_line:
-                if not self._initial_sync_done:
+                if not self.initial_sync_done:
                     self.closest_idx = self._full_nearest_idx(
                         self.racing_line, self.current_xy
                     )
-                    self._initial_sync_done = True
+                    self.initial_sync_done = True
                 else:
                     if self.closest_idx < 0 or self.closest_idx >= len(self.racing_line):
                         self.closest_idx = 0
                     row = self.racing_line[self.closest_idx]
                     dx = self.current_xy[0] - float(row[1])
                     dy = self.current_xy[1] - float(row[2])
-                    if math.hypot(dx, dy) > self._resync_distance_m:
+                    if math.hypot(dx, dy) > self.max_resync_dist:
                         self.closest_idx = self._full_nearest_idx(
                             self.racing_line, self.current_xy
                         )
@@ -206,7 +200,7 @@ class PathfinderNode(Node):
                             self.racing_line,
                             self.current_xy,
                             self.closest_idx,
-                            window=self._search_window,
+                            window=self.search_window,
                             allow_wrap=True,
                         )
 
@@ -240,7 +234,7 @@ class PathfinderNode(Node):
                         dyn_line,
                         self.current_xy,
                         dyn_idx,
-                        window=self._search_window,
+                        window=self.search_window,
                         allow_wrap=False,
                     )
                     target_xy, speed_ref_pct = self.pick_lookahead_point(

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -226,20 +226,27 @@ class PathfinderNode(Node):
 
             if self.line_manager.is_active:
                 dyn_line, dyn_idx = self.line_manager.get_line_and_idx()
-                # Dynamic lines (e.g. Bezier rejoin) are short and never closed,
-                # so the forward search must NOT wrap — wrapping would let the
-                # search snap back to idx 0 and pick a point behind the kart.
-                dyn_idx = self._nearest_idx_forward(
-                    dyn_line,
-                    self.current_xy,
-                    dyn_idx,
-                    window=self._search_window,
-                    allow_wrap=False,
-                )
-                target_xy, speed_ref_pct = self.pick_lookahead_point(
-                    dyn_line, dyn_idx, lookahead_m
-                )
-                self.line_manager.set_dynamic_closest_idx(dyn_idx)
+                if not dyn_line or dyn_idx < 0:
+                    # get_line_and_idx() can fall back to the closed racing line
+                    # Fallback to normal lookahead
+                    target_xy, speed_ref_pct = self.pick_lookahead_point(
+                        self.racing_line, self.closest_idx, lookahead_m
+                    )
+                else:
+                    # Dynamic lines (e.g. Bezier rejoin) are short and never closed,
+                    # so the forward search must NOT wrap — wrapping would let the
+                    # search snap back to idx 0 and pick a point behind the kart.
+                    dyn_idx = self._nearest_idx_forward(
+                        dyn_line,
+                        self.current_xy,
+                        dyn_idx,
+                        window=self._search_window,
+                        allow_wrap=False,
+                    )
+                    target_xy, speed_ref_pct = self.pick_lookahead_point(
+                        dyn_line, dyn_idx, lookahead_m
+                    )
+                    self.line_manager.set_dynamic_closest_idx(dyn_idx)
             else:
                 target_xy, speed_ref_pct = self.pick_lookahead_point(
                     self.racing_line, self.closest_idx, lookahead_m

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -61,6 +61,8 @@ class PathfinderNode(Node):
         self.initial_sync_done = bool(self.get_parameter("initial_sync_done").value)
         self.max_resync_dist = float(self.get_parameter("max_resync_dist").value)
 
+        self.max_closed_dist = float(self.get_parameter("max_closed_dist").value)
+
         self.pose_ready = False
         # self.pose_ready = True  # Dummy until localization works
         self.current_xy = (0.0, 0.0)
@@ -473,7 +475,7 @@ class PathfinderNode(Node):
         # Decide if this is a closed track. Most racing lines are one closed lap.
         s_end = float(line[-1][0])
         closed = s_end > 0.0 and (
-            math.hypot(line[0][1] - line[-1][1], line[0][2] - line[-1][2]) < 2.0
+            math.hypot(line[0][1] - line[-1][1], line[0][2] - line[-1][2]) <= self.max_closed_dist
         )
 
         if closed and s_target > s_end:

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -66,6 +66,17 @@ class PathfinderNode(Node):
         self.localization_sub = self.create_subscription(Odometry, "odom", self.localization, 10)
 
         self.closest_idx = 0
+        # First autonomous tick after pose_ready does an O(n) full-line nearest
+        # search so spawning or re-posing anywhere on the track syncs correctly.
+        # Subsequent ticks use a bounded forward search.
+        self._initial_sync_done = False
+        # Bounded forward search window in waypoints.
+        self._search_window = 80
+        # If the kart's distance to racing_line[closest_idx] exceeds this
+        # threshold, the windowed search is presumed stale (localization jump,
+        # large off-track excursion) and we re-run the full-line search.
+        # 20 m is well beyond any normal CTE/waypoint spacing on the racing line.
+        self._resync_distance_m = 20.0
 
         self.metrics_publisher = self.create_publisher(
             Float32MultiArray, "pathfinder_params", 5
@@ -165,6 +176,40 @@ class PathfinderNode(Node):
             else:
                 lookahead_m = self.min_lookahead_m
 
+            # Keep the racing-line closest_idx fresh every tick so CTE reflects
+            # actual proximity, even while a dynamic (rejoin) line is active.
+            # Three-tier strategy:
+            #   1. First autonomous tick after pose_ready: full O(n) search so
+            #      we sync correctly regardless of spawn location.
+            #   2. Localization jump / huge off-track excursion: full search
+            #      again (windowed search would stay stuck in the old region).
+            #   3. Normal operation: bounded forward search with wrap for the
+            #      closed racing line.
+            if self.racing_line:
+                if not self._initial_sync_done:
+                    self.closest_idx = self._full_nearest_idx(
+                        self.racing_line, self.current_xy
+                    )
+                    self._initial_sync_done = True
+                else:
+                    if self.closest_idx < 0 or self.closest_idx >= len(self.racing_line):
+                        self.closest_idx = 0
+                    row = self.racing_line[self.closest_idx]
+                    dx = self.current_xy[0] - float(row[1])
+                    dy = self.current_xy[1] - float(row[2])
+                    if math.hypot(dx, dy) > self._resync_distance_m:
+                        self.closest_idx = self._full_nearest_idx(
+                            self.racing_line, self.current_xy
+                        )
+                    else:
+                        self.closest_idx = self._nearest_idx_forward(
+                            self.racing_line,
+                            self.current_xy,
+                            self.closest_idx,
+                            window=self._search_window,
+                            allow_wrap=True,
+                        )
+
             cte = self.line_manager.compute_cte(
                 self.current_xy, self.racing_line, self.closest_idx
             )
@@ -176,22 +221,29 @@ class PathfinderNode(Node):
                 cross_track_error=cte,
             )
             self.line_manager.update(kart_state)
+            # Manager may snap closest_idx on deactivation.
+            self.closest_idx = kart_state.closest_idx
 
             if self.line_manager.is_active:
-                line, dyn_idx = self.line_manager.get_line_and_idx()
-                # Swap for pick_lookahead_point
-                orig_line, orig_idx = self.racing_line, self.closest_idx
-                self.racing_line = line
-                self.closest_idx = dyn_idx
-
-                target_xy, speed_ref_pct = self.pick_lookahead_point(lookahead_m)
-
-                self.line_manager.set_dynamic_closest_idx(self.closest_idx)
-                self.racing_line = orig_line
-                self.closest_idx = kart_state.closest_idx  # May have been updated by manager
+                dyn_line, dyn_idx = self.line_manager.get_line_and_idx()
+                # Dynamic lines (e.g. Bezier rejoin) are short and never closed,
+                # so the forward search must NOT wrap — wrapping would let the
+                # search snap back to idx 0 and pick a point behind the kart.
+                dyn_idx = self._nearest_idx_forward(
+                    dyn_line,
+                    self.current_xy,
+                    dyn_idx,
+                    window=self._search_window,
+                    allow_wrap=False,
+                )
+                target_xy, speed_ref_pct = self.pick_lookahead_point(
+                    dyn_line, dyn_idx, lookahead_m
+                )
+                self.line_manager.set_dynamic_closest_idx(dyn_idx)
             else:
-                self.closest_idx = kart_state.closest_idx
-                target_xy, speed_ref_pct = self.pick_lookahead_point(lookahead_m)
+                target_xy, speed_ref_pct = self.pick_lookahead_point(
+                    self.racing_line, self.closest_idx, lookahead_m
+                )
 
             motor_pct, steering_pct = pathfinder(
                 current_xy=self.current_xy,
@@ -322,16 +374,87 @@ class PathfinderNode(Node):
             return 1.0
         return x
 
-    def pick_lookahead_point(self, lookahead_m: float) -> Tuple[Tuple[float, float], float]:
-        """
-        Returns:
-          target_xy: (x_m, y_m) lookahead point on the racing line in map frame
-          speed_ref_pct: desired speed at that point as fraction of v_max_mps in [0..1]
+    @staticmethod
+    def _nearest_idx_forward(
+        line: list,
+        xy: Tuple[float, float],
+        start_idx: int,
+        window: int,
+        allow_wrap: bool,
+    ) -> int:
+        """Bounded forward nearest-index search.
 
-        Core idea (Pure Pursuit / Nav2 RPP): pick a point L meters ahead along the path.
-        Copied from Nav2
+        With allow_wrap=True the index wraps modulo len(line), which is only
+        safe on closed tracks. With allow_wrap=False the scan stops at the end
+        of the line so a short open path (e.g. a Bezier rejoin) cannot snap
+        backwards to a point behind the current progress.
         """
-        line = self.racing_line
+        n = len(line)
+        if n == 0:
+            return 0
+        if start_idx < 0 or start_idx >= n:
+            start_idx = 0
+        if allow_wrap:
+            max_offset = min(window, n)
+        else:
+            max_offset = min(window, n - start_idx)
+        best_i = start_idx
+        best_d2 = float("inf")
+        cx, cy = xy
+        for offset in range(max_offset):
+            if allow_wrap:
+                i = (start_idx + offset) % n
+            else:
+                i = start_idx + offset
+            dx = line[i][1] - cx
+            dy = line[i][2] - cy
+            d2 = dx * dx + dy * dy
+            if d2 < best_d2:
+                best_d2 = d2
+                best_i = i
+        return best_i
+
+    @staticmethod
+    def _full_nearest_idx(line: list, xy: Tuple[float, float]) -> int:
+        """O(n) full-line nearest search. Used for initial sync and resync
+        when the kart has moved far from the previously tracked index."""
+        n = len(line)
+        if n == 0:
+            return 0
+        cx, cy = xy
+        best_i = 0
+        best_d2 = float("inf")
+        for i in range(n):
+            dx = line[i][1] - cx
+            dy = line[i][2] - cy
+            d2 = dx * dx + dy * dy
+            if d2 < best_d2:
+                best_d2 = d2
+                best_i = i
+        return best_i
+
+    def pick_lookahead_point(
+        self,
+        line: list,
+        closest_idx: int,
+        lookahead_m: float,
+    ) -> Tuple[Tuple[float, float], float]:
+        """Pure-function lookahead pick from a given line and closest index.
+
+        Callers are responsible for keeping closest_idx fresh via the
+        `_nearest_idx_forward` / `_full_nearest_idx` helpers. Does not read
+        or mutate self.racing_line or self.closest_idx — this decoupling lets
+        the autonomous loop run the same logic on the racing line and on a
+        dynamic (rejoin) line without a fragile swap-and-restore pattern.
+
+        Returns:
+          target_xy: (x_m, y_m) lookahead point on `line` in map frame
+          speed_ref_pct: desired speed at that point as fraction of
+            v_max_mps in [0..1]
+
+        Core idea (Pure Pursuit / Nav2 RPP): pick a point L meters ahead along
+        the path.
+        """
         n = len(line)
         if n == 0:
             return self.current_xy, 0.0
@@ -339,34 +462,18 @@ class PathfinderNode(Node):
         if lookahead_m <= 0.0:
             lookahead_m = 0.01
 
-        cx, cy = self.current_xy
-
-        # Find closest index - windowed
-        # Tune these bounds
-        best_i = self.closest_idx
-        if best_i < 0 or best_i >= n:
-            best_i = 0
-
-        best_d2 = float("inf")
-        search_start = best_i
-        for offset in range(80):  # only look forward
-            i = (search_start + offset) % n
-            dx = line[i][1] - cx
-            dy = line[i][2] - cy
-            d2 = dx * dx + dy * dy
-            if d2 < best_d2:
-                best_d2 = d2
-                best_i = i
-
-        self.closest_idx = best_i
+        if closest_idx < 0 or closest_idx >= n:
+            closest_idx = 0
 
         # Use arc-length s_m to pick the lookahead point
-        s0 = float(line[best_i][0])  # s_m at closest point
+        s0 = float(line[closest_idx][0])  # s_m at closest point
         s_target = s0 + float(lookahead_m)
 
         # Decide if this is a closed track. Most racing lines are one closed lap.
         s_end = float(line[-1][0])
-        closed = s_end > 0.0 and (math.hypot(line[0][1] - line[-1][1], line[0][2] - line[-1][2]) < 2.0)
+        closed = s_end > 0.0 and (
+            math.hypot(line[0][1] - line[-1][1], line[0][2] - line[-1][2]) < 2.0
+        )
 
         if closed and s_target > s_end:
             s_target -= s_end  # wrap around to start
@@ -379,7 +486,7 @@ class PathfinderNode(Node):
                 j = n - 1
         else:
             # search forward from closest index (monotonic s)
-            j = best_i
+            j = closest_idx
             while j < n and float(line[j][0]) < s_target:
                 j += 1
             if j >= n:
@@ -387,7 +494,7 @@ class PathfinderNode(Node):
 
         tx = float(line[j][1])
         ty = float(line[j][2])
-        vx_mps = float(line[j][5])  # vx_mps column
+        vx_mps = float(line[j][5]) if len(line[j]) > 5 else 0.0
         speed_ref_pct = self._clamp01(vx_mps / self.v_max_mps) if self.v_max_mps > 1e-6 else 0.0
 
         return (tx, ty), speed_ref_pct

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -60,7 +60,6 @@ class PathfinderNode(Node):
         self.search_window = int(self.get_parameter("search_window").value)
         self.initial_sync_done = bool(self.get_parameter("initial_sync_done").value)
         self.max_resync_dist = float(self.get_parameter("max_resync_dist").value)
-
         self.max_closed_dist = float(self.get_parameter("max_closed_dist").value)
 
         self.pose_ready = False

--- a/src/autonomous_kart/autonomous_kart/params/pathfinder.yaml
+++ b/src/autonomous_kart/autonomous_kart/params/pathfinder.yaml
@@ -24,4 +24,8 @@ pathfinder_node:
     
     approach_dist_m: 1.0                 # Nav2: approach_velocity_scaling_dist (m)
     min_approach_speed_pct: 0.05         # like min_approach_linear_velocity / v_max
+
+    search_window: 80                    # Bounded forward search window (number of waypoints)
+    initial_sync_done: false             # First autonomous tick after pose_ready does an O(n) full-line nearest
+    max_resync_dist: 80                  # Max allowed distance to race line (m)
     

--- a/src/autonomous_kart/autonomous_kart/params/pathfinder.yaml
+++ b/src/autonomous_kart/autonomous_kart/params/pathfinder.yaml
@@ -27,6 +27,6 @@ pathfinder_node:
 
     search_window: 80                    # Bounded forward search window (number of waypoints)
     initial_sync_done: false             # First autonomous tick after pose_ready does an O(n) full-line nearest
-    max_resync_dist: 80                  # Max allowed distance to race line (m)
+    max_resync_dist: 80                  # Max allowed distance to race line (m) before falling back to a full O(n) search
     max_closed_dist: 2                   # Max distance between start and end for track to be considered closed (m)
     

--- a/src/autonomous_kart/autonomous_kart/params/pathfinder.yaml
+++ b/src/autonomous_kart/autonomous_kart/params/pathfinder.yaml
@@ -28,4 +28,5 @@ pathfinder_node:
     search_window: 80                    # Bounded forward search window (number of waypoints)
     initial_sync_done: false             # First autonomous tick after pose_ready does an O(n) full-line nearest
     max_resync_dist: 80                  # Max allowed distance to race line (m)
+    max_closed_dist: 2                   # Max distance between start and end for track to be considered closed (m)
     

--- a/src/autonomous_kart/test/test_pathfinder_closest_idx.py
+++ b/src/autonomous_kart/test/test_pathfinder_closest_idx.py
@@ -147,6 +147,10 @@ def test_pick_lookahead_point_is_pure(ros_ctx, tiny_racing_line):
             "min_reg_speed_pct": 0.20,
             "approach_dist_m": 1.0,
             "min_approach_speed_pct": 0.05,
+            "search_window": 80,
+            "initial_sync_done": False,
+            "max_resync_dist": 80.0,
+            "max_closed_dist": 2.0,
         }
     ):
         node = PathfinderNode()
@@ -190,6 +194,10 @@ def _params(line_path, system_state="AUTONOMOUS"):
         "min_reg_speed_pct": 0.20,
         "approach_dist_m": 1.0,
         "min_approach_speed_pct": 0.05,
+        "search_window": 80,
+        "initial_sync_done": False,
+        "max_resync_dist": 20.0,
+        "max_closed_dist": 2.0,
     }
 
 

--- a/src/autonomous_kart/test/test_pathfinder_closest_idx.py
+++ b/src/autonomous_kart/test/test_pathfinder_closest_idx.py
@@ -1,0 +1,373 @@
+"""
+Regression tests for the three closest-idx fixes in pathfinder_node:
+
+1. Stale racing-line closest_idx while a dynamic line is active
+2. Windowed forward search wrapping modulo on short non-closed lines
+3. Initial closest_idx sync when the kart spawns far from index 0
+
+The two search helpers are pure staticmethods, so we test them directly
+without rclpy. The "stale-CTE while dynamic line active" and "initial
+full-track sync" behaviors are tested at the node level.
+"""
+import math
+
+import pytest
+
+rclpy_mod = pytest.importorskip("rclpy")
+
+from autonomous_kart.nodes.pathfinder.pathfinder_node import PathfinderNode  # noqa: E402
+from autonomous_kart.nodes.pathfinder.dynamic_line import (  # noqa: E402
+    DynamicLineManager,
+    KartState,
+)
+
+
+# Row shape: (s_m, x_m, y_m, psi_rad, kappa_radpm, vx_mps, ax_mps2)
+def _straight_line(n=40, step=1.0, vx=10.0):
+    return [(i * step, i * step, 0.0, 0.0, 0.0, vx, 0.0) for i in range(n)]
+
+
+# --------------------------------------------------------------------------
+# Pure-helper tests (no ROS)
+# --------------------------------------------------------------------------
+
+
+def test_nearest_idx_forward_no_wrap_on_short_open_line():
+    """Issue 2: a short, non-closed line (e.g. a Bezier rejoin) must not
+    wrap modulo back to the start when the search window exceeds the
+    remaining length of the line.
+
+    Scenario: a Bezier-like 51-pt line where the kart is mid-line (far from
+    idx 0 on the line but close to it in map space — idx 0 is the start
+    of the Bezier, i.e. where the kart was when rejoin began). The forward
+    scan from dyn_idx must stay ahead of dyn_idx rather than wrap back
+    and snap to idx 0 behind the kart.
+    """
+    # Straight line along +x from x=0 to x=50, but with idx 0 relocated so
+    # it sits directly under where the kart currently is. This models the
+    # Bezier start-point being near the kart's current location.
+    kart_xy = (25.3, 0.0)
+    line = [(0.0, kart_xy[0], kart_xy[1], 0.0, 0.0, 10.0, 0.0)] + [
+        (float(i), float(i), 0.0, 0.0, 0.0, 10.0, 0.0) for i in range(1, 51)
+    ]
+
+    # With allow_wrap=False, the search starting from dyn_idx=25 must stay
+    # in [25..50] and not wrap back to idx 0 even though idx 0 is right
+    # underneath the kart.
+    idx_no_wrap = PathfinderNode._nearest_idx_forward(
+        line, kart_xy, start_idx=25, window=80, allow_wrap=False
+    )
+    assert 25 <= idx_no_wrap <= 50, (
+        f"no-wrap search snapped to {idx_no_wrap}, should stay forward of 25"
+    )
+    # Specifically, the nearest forward-only point to (25.3, 0) on the
+    # 1m-spaced straight is idx 25 (at x=25) or idx 26 (at x=26).
+    assert idx_no_wrap in (25, 26)
+
+    # Sanity: with allow_wrap=True the modular search visits idx 0 (the
+    # lure) and picks it — reproducing the original bug.
+    idx_wrap = PathfinderNode._nearest_idx_forward(
+        line, kart_xy, start_idx=25, window=80, allow_wrap=True
+    )
+    assert idx_wrap == 0
+
+
+def test_nearest_idx_forward_wrap_ok_on_closed_line():
+    """Racing line (closed, thousands of points) still benefits from wrap
+    when closest_idx is near the end and the actual nearest is past the
+    seam."""
+    # Square-ish closed loop made of 100 points returning to origin.
+    n = 100
+    pts = []
+    for i in range(n):
+        theta = 2.0 * math.pi * i / n
+        pts.append((i * 1.0, math.cos(theta), math.sin(theta), 0.0, 0.0, 10.0, 0.0))
+    # Kart sits near (1, 0) which is closest to idx 0 (and idx n-1 is also
+    # near it because it's a closed loop).
+    xy = (1.0, 0.0)
+    # Start at idx n-5, allow_wrap=True → must wrap to idx 0.
+    idx = PathfinderNode._nearest_idx_forward(
+        pts, xy, start_idx=n - 5, window=20, allow_wrap=True
+    )
+    # Accept idx in {n-4..n-1, 0, 1} — either side of the seam.
+    assert idx in set(range(n - 4, n)) | {0, 1}
+
+
+def test_nearest_idx_forward_clamps_start_idx():
+    line = _straight_line(n=10)
+    # Out-of-range start_idx should be treated as 0, not crash.
+    idx = PathfinderNode._nearest_idx_forward(
+        line, (5.0, 0.0), start_idx=999, window=80, allow_wrap=False
+    )
+    assert idx == 5
+
+
+def test_nearest_idx_forward_empty_line():
+    assert (
+        PathfinderNode._nearest_idx_forward([], (0.0, 0.0), 0, 80, True) == 0
+    )
+
+
+def test_full_nearest_idx_picks_absolute_best():
+    """Issue 3: full search must find the true nearest even when kart is
+    far from the last-known idx."""
+    line = _straight_line(n=100)
+    # Kart at (73, 0) → true nearest is idx 73.
+    xy = (73.0, 0.0)
+    assert PathfinderNode._full_nearest_idx(line, xy) == 73
+
+
+def test_full_nearest_idx_empty_line():
+    assert PathfinderNode._full_nearest_idx([], (1.0, 2.0)) == 0
+
+
+# --------------------------------------------------------------------------
+# pick_lookahead_point is now pure
+# --------------------------------------------------------------------------
+
+
+def test_pick_lookahead_point_is_pure(ros_ctx, tiny_racing_line):
+    """After the refactor pick_lookahead_point takes (line, idx, L) and
+    does not read/mutate self.racing_line or self.closest_idx."""
+    with ros_ctx(
+        {
+            "simulation_mode": True,
+            "system_frequency": 60,
+            "system_state": "IDLE",
+            "max_speed": 50,
+            "acceleration": 0.2,
+            "max_steering": 10,
+            "steering_accel": 0.05,
+            "line_path": tiny_racing_line,
+            "wheelbase_m": 1.05,
+            "v_max_mps": 15.0,
+            "steer_max_deg": 25.0,
+            "use_velocity_scaled_lookahead": True,
+            "lookahead_time_s": 0.6,
+            "min_lookahead_m": 3.0,
+            "max_lookahead_m": 8.0,
+            "use_curvature_regulation": True,
+            "min_radius_m": 12.0,
+            "min_reg_speed_pct": 0.20,
+            "approach_dist_m": 1.0,
+            "min_approach_speed_pct": 0.05,
+        }
+    ):
+        node = PathfinderNode()
+        try:
+            node.current_xy = (0.0, 0.0)
+            # Feed a short synthetic line instead of the racing line.
+            short = _straight_line(n=5, step=1.0, vx=10.0)
+            pre_racing = node.racing_line
+            pre_idx = node.closest_idx
+            tgt, _spd = node.pick_lookahead_point(short, 0, lookahead_m=2.0)
+            # Should target the last point of `short` (s=4 >= s_target=2 after
+            # the first index where s >= s_target, which is idx 2 at s=2.0).
+            assert tgt[0] == pytest.approx(2.0)
+            # pick_lookahead_point must not have rebound self.racing_line
+            assert node.racing_line is pre_racing
+            assert node.closest_idx == pre_idx
+        finally:
+            node.destroy_node()
+
+
+# --------------------------------------------------------------------------
+# Node-level integration: stale-CTE fix (Issue 1)
+# --------------------------------------------------------------------------
+
+
+def _params(line_path, system_state="AUTONOMOUS"):
+    return {
+        "simulation_mode": True,
+        "system_frequency": 60,
+        "system_state": system_state,
+        "max_speed": 50,
+        "acceleration": 0.2,
+        "max_steering": 10,
+        "steering_accel": 0.05,
+        "line_path": line_path,
+        "wheelbase_m": 1.05,
+        "v_max_mps": 15.0,
+        "steer_max_deg": 25.0,
+        "use_velocity_scaled_lookahead": True,
+        "lookahead_time_s": 0.6,
+        "min_lookahead_m": 3.0,
+        "max_lookahead_m": 8.0,
+        "use_curvature_regulation": True,
+        "min_radius_m": 12.0,
+        "min_reg_speed_pct": 0.20,
+        "approach_dist_m": 1.0,
+        "min_approach_speed_pct": 0.05,
+    }
+
+
+_LONG_LINE_CSV_HEADER = "s_m,x_m,y_m,psi_rad,kappa_radpm,vx_mps,ax_mps2\n"
+
+
+def _write_long_straight_line(path, n=200, step=1.0, vx=10.0):
+    lines = [_LONG_LINE_CSV_HEADER]
+    for i in range(n):
+        lines.append(f"{i * step},{i * step},0.0,0.0,0.0,{vx},0.0\n")
+    path.write_text("".join(lines))
+    return str(path)
+
+
+@pytest.fixture
+def long_racing_line(tmp_path):
+    return _write_long_straight_line(tmp_path / "long.csv", n=200)
+
+
+def _make_odom(x=0.0, y=0.0):
+    from nav_msgs.msg import Odometry
+
+    msg = Odometry()
+    msg.pose.pose.position.x = x
+    msg.pose.pose.position.y = y
+    msg.pose.pose.orientation.w = 1.0
+    return msg
+
+
+def test_racing_line_closest_idx_advances_while_dynamic_line_active(
+    ros_ctx, long_racing_line
+):
+    """Issue 1: while a dynamic strategy owns pick_lookahead_point, the
+    racing-line closest_idx must still advance with the kart so CTE is not
+    computed against a frozen waypoint.
+    """
+    from std_msgs.msg import Float32MultiArray
+
+    with ros_ctx(_params(long_racing_line, "AUTONOMOUS")):
+        node = PathfinderNode()
+        try:
+            # Install an always-active strategy that returns a long-enough
+            # dynamic line so the manager does not auto-deactivate at the
+            # end-of-line check.
+            from autonomous_kart.nodes.pathfinder.dynamic_line import LineStrategy
+
+            class _Sticky(LineStrategy):
+                priority = 1
+
+                def should_activate(self, s, l):
+                    return True
+
+                def should_deactivate(self, s, l):
+                    return False
+
+                def generate(self, s, l):
+                    # Synthetic dynamic line: 60 points along +x from kart,
+                    # covering 60 m → longer than the end-of-line threshold
+                    # (len - 5) check.
+                    cx, cy = s.xy
+                    pts = [
+                        (float(i), cx + float(i), cy, 0.0, 0.0, 5.0)
+                        for i in range(60)
+                    ]
+                    # Merge index on racing line: 60 m further along +x.
+                    target_idx = min(
+                        int(cx + 60.0), len(l) - 1
+                    )  # racing line is spaced 1 m
+                    return pts, target_idx
+
+            # Replace registered strategies with ours.
+            node.line_manager._strategies = []
+            node.line_manager.register(_Sticky())
+
+            # Start kart at origin; first autonomous tick will do the full
+            # initial sync and set closest_idx = 0.
+            node.current_xy = (0.0, 0.0)
+            node.current_yaw = 0.0
+            node.current_speed_mps = 0.0
+            node.pose_ready = True
+
+            msg = Float32MultiArray(data=[0.0, 0.0])
+            # Tick 1: initial sync + activate dynamic line.
+            node.autonomous_control_loop(msg)
+            assert node.line_manager.is_active
+            idx_at_start = node.closest_idx
+            assert idx_at_start == 0
+
+            # Simulate the kart driving along the dynamic line: move it 50 m
+            # forward without deactivating the strategy. After each pose
+            # update, the racing-line closest_idx MUST advance.
+            for step_x in (10.0, 20.0, 30.0, 40.0, 50.0):
+                node.current_xy = (step_x, 0.0)
+                node.autonomous_control_loop(msg)
+                # Dynamic line is still active.
+                assert node.line_manager.is_active
+                # Racing-line closest_idx (on the long 1 m-spaced straight
+                # line) should have advanced to ~step_x.
+                assert abs(node.closest_idx - int(step_x)) <= 2, (
+                    f"racing-line closest_idx stuck at {node.closest_idx} "
+                    f"while kart moved to x={step_x}"
+                )
+
+            # CTE (via compute_cte) must now be small: the advanced
+            # closest_idx points at a waypoint right under the kart.
+            cte = node.line_manager.compute_cte(
+                node.current_xy, node.racing_line, node.closest_idx
+            )
+            assert cte < 1.0, f"CTE inflated ({cte:.2f}m) — closest_idx stale"
+        finally:
+            node.destroy_node()
+
+
+# --------------------------------------------------------------------------
+# Node-level integration: initial full-track search (Issue 3)
+# --------------------------------------------------------------------------
+
+
+def test_initial_sync_picks_true_nearest_when_kart_spawns_far_from_idx0(
+    ros_ctx, long_racing_line
+):
+    """Issue 3: if the kart's first pose lands far from racing_line[0],
+    the first autonomous tick must do an O(n) search rather than trust
+    the default closest_idx=0."""
+    from std_msgs.msg import Float32MultiArray
+
+    with ros_ctx(_params(long_racing_line, "AUTONOMOUS")):
+        node = PathfinderNode()
+        try:
+            node.current_xy = (150.0, 0.0)  # well beyond the 80-window from 0
+            node.current_yaw = 0.0
+            node.current_speed_mps = 0.0
+            node.pose_ready = True
+
+            assert node.closest_idx == 0
+            assert not node._initial_sync_done
+
+            node.autonomous_control_loop(Float32MultiArray(data=[0.0, 0.0]))
+
+            assert node._initial_sync_done
+            # True nearest on a 1 m-spaced straight is idx 150.
+            assert abs(node.closest_idx - 150) <= 1, (
+                f"initial sync failed to find true nearest; got "
+                f"{node.closest_idx}"
+            )
+        finally:
+            node.destroy_node()
+
+
+def test_resync_on_large_localization_jump(ros_ctx, long_racing_line):
+    """Bonus: a huge jump (localization glitch, operator re-poses the kart)
+    triggers another full search so the windowed scan doesn't stay stuck."""
+    from std_msgs.msg import Float32MultiArray
+
+    with ros_ctx(_params(long_racing_line, "AUTONOMOUS")):
+        node = PathfinderNode()
+        try:
+            node.current_xy = (0.0, 0.0)
+            node.current_yaw = 0.0
+            node.current_speed_mps = 0.0
+            node.pose_ready = True
+
+            # Establish initial sync at idx 0.
+            node.autonomous_control_loop(Float32MultiArray(data=[0.0, 0.0]))
+            assert node.closest_idx == 0
+
+            # Teleport to x=180 — outside the bounded search window (80).
+            node.current_xy = (180.0, 0.0)
+            node.autonomous_control_loop(Float32MultiArray(data=[0.0, 0.0]))
+            # Resync branch should have fired (distance 180 > 20 m).
+            assert abs(node.closest_idx - 180) <= 1
+        finally:
+            node.destroy_node()

--- a/src/autonomous_kart/test/test_pathfinder_closest_idx.py
+++ b/src/autonomous_kart/test/test_pathfinder_closest_idx.py
@@ -27,9 +27,7 @@ def _straight_line(n=40, step=1.0, vx=10.0):
     return [(i * step, i * step, 0.0, 0.0, 0.0, vx, 0.0) for i in range(n)]
 
 
-# --------------------------------------------------------------------------
 # Pure-helper tests (no ROS)
-# --------------------------------------------------------------------------
 
 
 def test_nearest_idx_forward_no_wrap_on_short_open_line():
@@ -121,9 +119,7 @@ def test_full_nearest_idx_empty_line():
     assert PathfinderNode._full_nearest_idx([], (1.0, 2.0)) == 0
 
 
-# --------------------------------------------------------------------------
 # pick_lookahead_point is now pure
-# --------------------------------------------------------------------------
 
 
 def test_pick_lookahead_point_is_pure(ros_ctx, tiny_racing_line):
@@ -170,10 +166,6 @@ def test_pick_lookahead_point_is_pure(ros_ctx, tiny_racing_line):
         finally:
             node.destroy_node()
 
-
-# --------------------------------------------------------------------------
-# Node-level integration: stale-CTE fix (Issue 1)
-# --------------------------------------------------------------------------
 
 
 def _params(line_path, system_state="AUTONOMOUS"):
@@ -311,11 +303,6 @@ def test_racing_line_closest_idx_advances_while_dynamic_line_active(
             node.destroy_node()
 
 
-# --------------------------------------------------------------------------
-# Node-level integration: initial full-track search (Issue 3)
-# --------------------------------------------------------------------------
-
-
 def test_initial_sync_picks_true_nearest_when_kart_spawns_far_from_idx0(
     ros_ctx, long_racing_line
 ):
@@ -333,11 +320,11 @@ def test_initial_sync_picks_true_nearest_when_kart_spawns_far_from_idx0(
             node.pose_ready = True
 
             assert node.closest_idx == 0
-            assert not node._initial_sync_done
+            assert not node.initial_sync_done
 
             node.autonomous_control_loop(Float32MultiArray(data=[0.0, 0.0]))
 
-            assert node._initial_sync_done
+            assert node.initial_sync_done
             # True nearest on a 1 m-spaced straight is idx 150.
             assert abs(node.closest_idx - 150) <= 1, (
                 f"initial sync failed to find true nearest; got "

--- a/src/autonomous_kart/test/test_pathfinder_closest_idx.py
+++ b/src/autonomous_kart/test/test_pathfinder_closest_idx.py
@@ -161,8 +161,8 @@ def test_pick_lookahead_point_is_pure(ros_ctx, tiny_racing_line):
             pre_racing = node.racing_line
             pre_idx = node.closest_idx
             tgt, _spd = node.pick_lookahead_point(short, 0, lookahead_m=2.0)
-            # Should target the last point of `short` (s=4 >= s_target=2 after
-            # the first index where s >= s_target, which is idx 2 at s=2.0).
+            # Should target the first point in `short` where s >= s_target,
+            # which is idx 2 at s=2.0.
             assert tgt[0] == pytest.approx(2.0)
             # pick_lookahead_point must not have rebound self.racing_line
             assert node.racing_line is pre_racing

--- a/src/autonomous_kart/test/test_pathfinder_node.py
+++ b/src/autonomous_kart/test/test_pathfinder_node.py
@@ -39,6 +39,10 @@ def _params(line_path, system_state="AUTONOMOUS"):
         "min_reg_speed_pct": 0.20,
         "approach_dist_m": 1.0,
         "min_approach_speed_pct": 0.05,
+        "search_window": 80,
+        "initial_sync_done": False,
+        "max_resync_dist": 80.0,
+        "max_closed_dist": 2.0,
     }
 
 


### PR DESCRIPTION
This pull request significantly improves the robustness and correctness of the pathfinding logic in the `PathfinderNode` by fixing multiple issues with waypoint tracking and lookahead computation, especially when switching between the main racing line and dynamic (e.g., rejoin) lines. The changes ensure the closest waypoint index remains accurate even during dynamic line activation, prevent incorrect waypoint selection on open (non-looping) paths, and make the lookahead logic pure and stateless. Extensive regression tests have been added to verify these behaviors.

**Waypoint tracking and search improvements:**

* Added a three-tiered strategy for maintaining the closest waypoint index (`closest_idx`): (1) initial full O(n) sync on the first tick after pose readiness, (2) resync on large localization jumps or off-track excursions, and (3) efficient bounded forward search during normal operation. This ensures correct index tracking regardless of spawn location or localization glitches. [[1]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255R69-R79) [[2]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255R179-R212)
* Refactored the forward search logic into `_nearest_idx_forward` (bounded, optionally wrapping) and `_full_nearest_idx` (full O(n) search), handling both closed racing lines and short, open dynamic lines correctly.

**Dynamic line handling:**

* Ensured that when a dynamic line is active, the bounded forward search does not wrap around, preventing the kart from targeting waypoints behind its current progress on open lines. [[1]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255R224-R246) [[2]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255L325-R476)
* Updated the main loop so the racing line's `closest_idx` is always kept up to date, even when a dynamic line is active, preventing inflated cross-track errors (CTE) when returning to the racing line.

**Lookahead logic refactor:**

* Refactored `pick_lookahead_point` to be a pure function that takes a line and index as arguments, removing side effects and making the logic reusable for both racing and dynamic lines. [[1]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255L325-R476) [[2]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255L382-R497)

**Testing and regression coverage:**

* Added a comprehensive new test suite (`test_pathfinder_closest_idx.py`) covering all key scenarios: stale `closest_idx` during dynamic line activation, correct handling of open/closed lines in forward search, initial sync when spawning far from index 0, and resync after large localization jumps.