### PR TITLE
feat(apis): add line and odom APIs to get called by UI

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - ROS_LOCALHOST_ONLY=1
     ports:
       - "8000:8000"
-    devices:
-      - "/dev/ttyACM0:/dev/ttyACM0"
+#    devices:
+#      - "/dev/ttyACM0:/dev/ttyACM0"
 #      - "/dev/ttyHS2:/dev/ttyHS2"         # GNSS
 #      - "/dev/spidev12.0:/dev/spidev12.0" # SPI bus 12, CS0
     stdin_open: true

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_api.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_api.py
@@ -20,7 +20,36 @@ def cors(response):
 def ping():
     return jsonify({"ping": "pong"})
 
+_STATIC_LINE_CACHE = None
 
+def _load_static_line(path):
+    """
+    Load racing line once
+    returns: list of full waypoint dicts
+    """
+    global _STATIC_LINE_CACHE
+    if _STATIC_LINE_CACHE is not None:
+        return _STATIC_LINE_CACHE
+    if not os.path.exists(path):
+        return []
+    rows = []
+    with open(path, "r") as f:
+        for row in f:
+            parts = row.strip().split(",")
+            if len(parts) >= 6:
+                try:
+                    rows.append({
+                        "s": float(parts[0]),
+                        "x": float(parts[1]),
+                        "y": float(parts[2]),
+                        "psi": float(parts[3]),
+                        "kappa": float(parts[4]),
+                        "vx": float(parts[5]),
+                    })
+                except ValueError:
+                    continue
+    _STATIC_LINE_CACHE = rows
+    return rows
 @app.route("/get_logs", methods=["GET"])
 def get_logs():
     if not master_node:
@@ -72,7 +101,7 @@ def odom():
 
 @app.route("/racing_line", methods=["GET"])
 def racing_line():
-    path = "/ws/data/racing_line/line.csv"
+    path = master_node.path
     if not os.path.exists(path):
         return jsonify({"points": []})
     points = []
@@ -90,6 +119,28 @@ def racing_line():
 @app.route("/viz")
 def viz():
     return send_from_directory("/ws/viz", "viz.html")
+
+@app.route("/map", methods=["GET"])
+def map_endpoint():
+    waypoints = _load_static_line(master_node.path)
+    if not waypoints:
+        return jsonify({"error": "racing line not found", "waypoints": []}), 404
+    return jsonify({
+        "path": master_node.path,
+        "count": len(waypoints),
+        "waypoints": waypoints,
+    })
+
+
+@app.route("/lines", methods=["GET"])
+def lines_endpoint():
+    if not master_node:
+        return jsonify({"error": "not initialized"}), 500
+    static_xy = [[w["x"], w["y"]] for w in _load_static_line(master_node.path)]
+    return jsonify({
+        "static": static_xy,
+        "dynamic": master_node.get_dynamic_line(),
+    })
 
 
 def start(node: MasterNode) -> None:

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -26,6 +26,7 @@ class MasterNode(Node):
         self.logger = self.get_logger()
         self.state = self.get_parameter("system_state").value
         self.system_frequency = self.get_parameter("system_frequency").value
+        self.path = self.get_parameter("path").value
 
         assert self.state in [s.value for s in STATES]
 
@@ -70,7 +71,25 @@ class MasterNode(Node):
         self.create_subscription(Float32, "cmd_vel", self._velocity_callback, 5)
         self.create_subscription(Float32, "cmd_turn", self._turn_callback, 5)
 
+        # Dynamic line output
+        self.dynamic_line_data = {"active": False, "strategy": None, "merge_idx": -1, "points": []}
+        self.create_subscription(
+            String, "pathfinder/dynamic_line", self.dynamic_line_callback, 1
+        )
+
         self.logger.info("Initialize Master Node")
+
+    def _dynamic_line_callback(self, msg: String):
+        try:
+            data = json.loads(msg.data)
+        except Exception:
+            return
+        with self._lock:
+            self.dynamic_line_data = data
+
+    def get_dynamic_line(self):
+        with self._lock:
+            return dict(self.dynamic_line_dat)
 
     def logs_callback(self, msg):
         logs = json.loads(msg.data)

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -28,7 +28,7 @@ class MasterNode(Node):
         self.logger = self.get_logger()
         self.state = self.get_parameter("system_state").value
         self.system_frequency = self.get_parameter("system_frequency").value
-        self.path = self.get_parameter("path").value
+        self.path = self.get_parameter("line_path").value
 
         assert self.state in [s.value for s in STATES]
 

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -49,7 +49,15 @@ class MasterNode(Node):
         )
 
         # Odom + command state for viz
-        self.odom_data = {"x": 0.0, "y": 0.0, "yaw": 0.0, "speed": 0.0}
+        self.odom_data = {
+            "x": 0.0, "y": 0.0, "z": 0.0,
+            "yaw": 0.0,
+            "qx": 0.0, "qy": 0.0, "qz": 0.0, "qw": 1.0,
+            "vx": 0.0, "vy": 0.0, "vz": 0.0,
+            "wx": 0.0, "wy": 0.0, "wz": 0.0,
+            "speed": 0.0,
+            "stamp_ns": 0,
+        }
         self.cmd_data = {"motor": 0.0, "steer": 0.0}
 
         self.odom_subscriber = self.create_subscription(
@@ -96,12 +104,23 @@ class MasterNode(Node):
     def odom_callback(self, msg: Odometry):
         p = msg.pose.pose.position
         q = msg.pose.pose.orientation
+        tl = msg.twist.twist.linear
+        ta = msg.twist.twist.angular
         import math
-        yaw = math.atan2(2.0 * (q.w * q.z + q.x * q.y), 1.0 - 2.0 * (q.y * q.y + q.z * q.z))
+        yaw = math.atan2(
+            2.0 * (q.w * q.z + q.x * q.y),
+            1.0 - 2.0 * (q.y * q.y + q.z * q.z),
+        )
+        stamp = msg.header.stamp
         with self._lock:
             self.odom_data = {
-                "x": p.x, "y": p.y, "yaw": yaw,
-                "speed": msg.twist.twist.linear.x,
+                "x": p.x, "y": p.y, "z": p.z,
+                "yaw": yaw,
+                "qx": q.x, "qy": q.y, "qz": q.z, "qw": q.w,
+                "vx": tl.x, "vy": tl.y, "vz": tl.z,
+                "wx": ta.x, "wy": ta.y, "wz": ta.z,
+                "speed": tl.x,
+                "stamp_ns": stamp.sec * 1_000_000_000 + stamp.nanosec,
             }
 
     def _velocity_callback(self, msg: Float32):

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -6,7 +6,6 @@ import rclpy
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from std_msgs.msg import String, Float32MultiArray, Float32
-from nav_msgs.msg import Odometry
 
 
 
@@ -91,7 +90,7 @@ class MasterNode(Node):
 
     def get_dynamic_line(self):
         with self._lock:
-            return dict(self.dynamic_line_dat)
+            return dict(self.dynamic_line_data)
 
     def logs_callback(self, msg):
         logs = json.loads(msg.data)

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -6,6 +6,8 @@ import rclpy
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from std_msgs.msg import String, Float32MultiArray, Float32
+from nav_msgs.msg import Odometry
+
 
 
 class STATES(Enum):
@@ -79,7 +81,7 @@ class MasterNode(Node):
 
         self.logger.info("Initialize Master Node")
 
-    def _dynamic_line_callback(self, msg: String):
+    def dynamic_line_callback(self, msg: String):
         try:
             data = json.loads(msg.data)
         except Exception:

--- a/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
@@ -7,6 +7,7 @@ import rclpy
 from sensor_msgs.msg import Image
 from rclpy.node import Node
 from std_msgs.msg import Float32, Float32MultiArray, Int16, String
+from nav_msgs.msg import Odometry
 
 
 class MetricsNode(Node):

--- a/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
@@ -44,6 +44,7 @@ class MetricsNode(Node):
             "e_comms/pwm_rx/motor": Int16,
             "e_comms/pwm_rx/steering": Int16,
             "pathfinder_params": Float32MultiArray,
+            "odom": Odometry,
         }
         for topic, msg_type in publishers.items():
             self.cmd_vel_sub = self.create_subscription(
@@ -93,6 +94,17 @@ class MetricsNode(Node):
                 "width": msg.width,
                 "height": msg.height,
                 "encoding": msg.encoding,
+            }
+        elif isinstance(msg, Odometry):
+            p = msg.pose.pose.position
+            q = msg.pose.pose.orientation
+            tl = msg.twist.twist.linear
+            ta = msg.twist.twist.angular
+            record["value"] = {
+                "x": p.x, "y": p.y, "z": p.z,
+                "qx": q.x, "qy": q.y, "qz": q.z, "qw": q.w,
+                "vx": tl.x, "vy": tl.y, "vz": tl.z,
+                "wx": ta.x, "wy": ta.y, "wz": ta.z,
             }
 
         with self._lock:

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder.py
@@ -82,7 +82,7 @@ def pathfinder(
     # If target is behind, can't pure pursue so force a 0 turn + slow.
     if x_v <= 1e-6:
         steering_pct = -1.0 if y_v < 0.0 else 1.0
-        return 100 * min(0.10, desired_speed_pct), 0
+        return 100 * min(0.10, desired_speed_pct), 0.0
 
     # Use actual distance to target as L (pure pursuit chord length).
     # If target is actually a lookahead point, this will be close to Ld regardless
@@ -138,6 +138,6 @@ def pathfinder(
     elif throttle_pct > 1.0:
         throttle_pct = 1.0
 
-    return throttle_pct * 100, steering_pct * steer_max_deg
+    return throttle_pct * 100.0, steering_pct * steer_max_deg
 
 

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -70,6 +70,11 @@ class PathfinderNode(Node):
 
         self.localization_sub = self.create_subscription(Odometry, "odom", self.localization, 10)
 
+        self.dynamic_line_pub = self.create_publisher(
+            String, "pathfinder/dynamic_line", 1
+        )
+        self.create_timer(0.5, self.publish_dynamic_line)  # 2 Hz
+
         self.closest_idx = 0
 
 
@@ -500,6 +505,22 @@ class PathfinderNode(Node):
         speed_ref_pct = self._clamp01(vx_mps / self.v_max_mps) if self.v_max_mps > 1e-6 else 0.0
 
         return (tx, ty), speed_ref_pct
+
+    def _publish_dynamic_line(self):
+        import json
+        if self.line_manager.is_active:
+            line = self.line_manager.dynamic_line
+            payload = {
+                "active": True,
+                "strategy": type(self.line_manager.active_strategy).__name__,
+                "merge_idx": int(self.line_manager.merge_idx),
+                "points": [[float(p[1]), float(p[2])] for p in line],
+            }
+        else:
+            payload = {"active": False, "strategy": None, "merge_idx": -1, "points": []}
+        self.dynamic_line_pub.publish(
+            String(data=json.dumps(payload, separators=(",", ":")))
+        )
 
 
 def main(args=None):

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -506,7 +506,7 @@ class PathfinderNode(Node):
 
         return (tx, ty), speed_ref_pct
 
-    def _publish_dynamic_line(self):
+    def publish_dynamic_line(self):
         import json
         if self.line_manager.is_active:
             line = self.line_manager.dynamic_line

--- a/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.py
@@ -141,6 +141,11 @@ class PathfinderNode(Node):
         self.pose_ready = True
 
     def update_state(self, msg: String):
+        if msg.data != self.state:
+            # Set speed to zero on state change
+            self.speed = 0.0
+            self.expected_speed = 0.0
+            self.motor_publisher.publish(Float32(data=0.0))
         if msg.data not in [s.value for s in STATES]:
             self.logger.error(f"State {msg.data} not recognized")
             return

--- a/src/autonomous_kart/autonomous_kart/params/system.yaml
+++ b/src/autonomous_kart/autonomous_kart/params/system.yaml
@@ -3,3 +3,4 @@
     simulation_mode: false
     system_state: "IDLE"  # "STOPPED", "IDLE", "MANUAL", "AUTONOMOUS"
     system_frequency: 60  # Speed of hot loop (Hertz)
+    line_path: "/ws/data/racing_line/line.csv"

--- a/src/autonomous_kart/setup.py
+++ b/src/autonomous_kart/setup.py
@@ -20,6 +20,7 @@ setup(
         'autonomous_kart.nodes.metrics',
         'autonomous_kart.nodes.master',
         'autonomous_kart.nodes.localization',
+'autonomous_kart.nodes.pathfinder.strategies',
     ],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/src/autonomous_kart/setup.py
+++ b/src/autonomous_kart/setup.py
@@ -20,7 +20,7 @@ setup(
         'autonomous_kart.nodes.metrics',
         'autonomous_kart.nodes.master',
         'autonomous_kart.nodes.localization',
-'autonomous_kart.nodes.pathfinder.strategies',
+        'autonomous_kart.nodes.pathfinder.strategies',
     ],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the autonomous kart system, focusing on improved racing line management, dynamic line publishing, and richer odometry and metrics logging. Key changes include the addition of endpoints for accessing static and dynamic racing lines, expanded odometry data, and the integration of dynamic line publishing from the pathfinder node. There are also supporting changes to configuration and device handling.

**API and Feature Additions:**

* Added `/map` and `/lines` endpoints to the `master_api.py` Flask app to expose static and dynamic racing line data, using a new `_load_static_line` function for efficient file access. (`[[1]](diffhunk://#diff-34a2533245ff40828e6ed8e17ebf077111d929a8dc1cc09df7fcc6f6df66f890L23-R52)`, `[[2]](diffhunk://#diff-34a2533245ff40828e6ed8e17ebf077111d929a8dc1cc09df7fcc6f6df66f890R123-R144)`)
* The `racing_line` endpoint now uses a configurable path from the master node, allowing flexibility in line file location. (`[src/autonomous_kart/autonomous_kart/nodes/master/master_api.pyL75-R104](diffhunk://#diff-34a2533245ff40828e6ed8e17ebf077111d929a8dc1cc09df7fcc6f6df66f890L75-R104)`)
* `master_node.py` now exposes the current dynamic line via `get_dynamic_line`, and subscribes to the new `pathfinder/dynamic_line` topic. (`[src/autonomous_kart/autonomous_kart/nodes/master/master_node.pyR75-R94](diffhunk://#diff-989fcf844bf787f311bfce0ff46b76e959d105f2d6caa5789026657acc170076R75-R94)`)

**Odometry and Metrics Improvements:**

* Expanded the odometry data structure in `master_node.py` to include full position, orientation (quaternion), linear and angular velocities, and timestamp, with corresponding updates in the odometry callback. (`[[1]](diffhunk://#diff-989fcf844bf787f311bfce0ff46b76e959d105f2d6caa5789026657acc170076L52-R62)`, `[[2]](diffhunk://#diff-989fcf844bf787f311bfce0ff46b76e959d105f2d6caa5789026657acc170076R127-R143)`)
* The metrics node now records odometry messages with full pose and twist data, improving logging and analysis capabilities. (`[[1]](diffhunk://#diff-04a607577393bd7fc6c3ef71e2facdddcdc132ed82595ad73d8ada69609aeda8R48)`, `[[2]](diffhunk://#diff-04a607577393bd7fc6c3ef71e2facdddcdc132ed82595ad73d8ada69609aeda8R99-R109)`)

**Dynamic Line Publishing:**

* The pathfinder node now publishes dynamic racing line data (active status, strategy, merge index, and points) at 2 Hz on the `pathfinder/dynamic_line` topic, enabling real-time visualization and monitoring. (`[[1]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255R73-R77)`, `[[2]](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255R514-R529)`)

**Configuration and Setup:**

* Added a `line_path` parameter to the system configuration (`system.yaml`) and updated the master node to read the racing line path from this parameter. (`Ff0f3754L26R27`, `Ff0f3754L49R51`, `Ff0f3754L49R51`, `[src/autonomous_kart/autonomous_kart/params/system.yamlR6](diffhunk://#diff-9da709da86795c654d2d5c42d8059fd5b3bb375beb49530473b81f199ed4d543R6)`)
* Updated the Python package setup to include the pathfinder strategies module. (`[src/autonomous_kart/setup.pyR23](diffhunk://#diff-a057cd6dae0c14b25a829ca0ec6003249bbc0f44acb2c5853fb549ef7698dd9eR23)`)
* Commented out device mappings in `docker-compose.yml` for easier development without hardware. (`[compose/docker-compose.ymlL16-R17](diffhunk://#diff-6279b4379956d40a7c808ee22b5f1005cb7d1f6bfa77d45adc2e004f7ef3e6f9L16-R17)`)

**Control and Logic Fixes:**

* Minor corrections to control logic in `pathfinder.py` for more precise throttle and steering outputs. (`[[1]](diffhunk://#diff-abd5995da60b22ec655932ac2cc61576a817336ca8b29c47de5d7b4d036b4e95L85-R85)`, `[[2]](diffhunk://#diff-abd5995da60b22ec655932ac2cc61576a817336ca8b29c47de5d7b4d036b4e95L141-R141)`)
* Ensured the pathfinder node sets speed to zero on state changes for safer transitions. (`[src/autonomous_kart/autonomous_kart/nodes/pathfinder/pathfinder_node.pyR144-R148](diffhunk://#diff-2e4443c2a5a6c41c70b412efbe8db892cbf492bc27ab9f35830815800a7ee255R144-R148)`)