### PR TITLE
Update ECOMMS for manual mode support

### DIFF
--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -31,7 +31,7 @@ class AdcbStatus:
     steering_pwm: int # Integer value of the steering PWM (1000-2000)
 
 
-def pack_control_message(throttle_percent: float, steering_angle: float, logger) -> bytes:
+def pack_control_message(throttle_percent: float, steering_angle: float) -> bytes:
     """
     Pack the throttle and steering commands into a bytearray buffer for CAN
     Caller is responsible for ensuring values are within expected ranges.
@@ -47,7 +47,6 @@ def pack_control_message(throttle_percent: float, steering_angle: float, logger)
     """
     throttle = int(1000 * (throttle_percent / 100.0))  # 0-1000
     steering = int(500 + 500 * (steering_angle / 100.0))  # -100..100 -> 0..1000
-    logger.info(f"Steering in ecomms: {steering}, {throttle}")
 
     data = bytearray(8)
     data[0] = throttle & 0xFF

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -74,8 +74,9 @@ class ECommsNode(Node):
         self.steering_sub = self.create_subscription(Float32, "cmd_turn", self.cmd_steer, 5)
         self.throttle_sub = self.create_subscription(Float32, "cmd_vel", self.cmd_thr, 5)
 
-        # CAN TX timer at 20Hz to send latest command values
-        self.timer = self.create_timer(1.0 / 20.0, self.can_tx)
+        # CAN TX timer at 50Hz to send latest command values
+        # TODO: make a parameter
+        self.timer = self.create_timer(1.0 / 50.0, self.can_tx)
 
         # Publishers
         self.adcb_state_pub = self.create_publisher(

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -73,6 +73,7 @@ class ECommsNode(Node):
         # out on the CAN bus at a fixed rate in can_tx()
         self.steering_sub = self.create_subscription(Float32, "cmd_turn", self.cmd_steer, 5)
         self.throttle_sub = self.create_subscription(Float32, "cmd_vel", self.cmd_thr, 5)
+        self.last_command_time = self.get_clock().now()
 
         # CAN TX timer at 50Hz to send latest command values
         # TODO: make a parameter
@@ -126,6 +127,7 @@ class ECommsNode(Node):
             self.throttle_percent = 0.0  # Default to zero if invalid command
             return
         self.throttle_percent = throttle_msg.data
+        self.last_command_time = self.get_clock().now()
 
     def cmd_steer(self, steering_msg: Float32):
         self.cmd_count += 1
@@ -134,10 +136,21 @@ class ECommsNode(Node):
             self.steering_angle = 0.0  # Default to straight if invalid command
             return
         self.steering_angle = steering_msg.data
+        self.last_command_time = self.get_clock().now()
     #--------------------------------------------------------------------------#
     
     # CAN TX ------------------------------------------------------------------#
     def can_tx(self):
+        """
+        Send the latest throttle and steering commands on the CAN bus at a fixed rate.
+        If we have not received any new commands for a while (1 sec) reset to default/zero commands instead.
+        """
+        if (self.get_clock().now() - self.last_command_time).nanoseconds / 1e9 > 1.0:
+            # No recent commands, default to zero
+            self.throttle_percent = 0.0
+            self.steering_angle = 0.0
+            # TODO: make the 1 sec timeout a parameter
+
         tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle)
         if self.bus is not None:
             msg = can.Message(

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -69,13 +69,13 @@ class ECommsNode(Node):
         self.create_timer(5.0, self.log_command_rate)
 
         # Subscribe for throttle and steering commands
-        # Each command updates the internal state, and the latest values are sent out on the CAN bus at a fixed rate in on_timer()
+        # Each command updates the internal state, and the latest values are sent
+        # out on the CAN bus at a fixed rate in can_tx()
         self.steering_sub = self.create_subscription(Float32, "cmd_turn", self.cmd_steer, 5)
         self.throttle_sub = self.create_subscription(Float32, "cmd_vel", self.cmd_thr, 5)
 
         # CAN TX timer at 20Hz to send latest command values
-        self.timer = self.create_timer(1.0 / 10.0, self.on_timer)
-
+        self.timer = self.create_timer(1.0 / 20.0, self.can_tx)
 
         # Publishers
         self.adcb_state_pub = self.create_publisher(
@@ -136,12 +136,8 @@ class ECommsNode(Node):
     #--------------------------------------------------------------------------#
     
     # CAN TX ------------------------------------------------------------------#
-    def on_timer(self):
-        tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle, self.logger)
-        # self.logger.info(f"Steering: {steering_msg.data}")
-        for i, hx in enumerate(list(tx_data)):
-            self.logger.info(f"{i}: {hx}")
-        self.logger.info(f"tx_data: {tx_data}")
+    def can_tx(self):
+        tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle)
         if self.bus is not None:
             msg = can.Message(
                 arbitration_id=CONTROL_ID,

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -94,6 +94,7 @@ class ECommsNode(Node):
         # Init finished
         self.logger.info("Initialize EComms Node")
 
+    # CAN RX ------------------------------------------------------------------#
     def _on_can_msg(self, msg: can.Message):
         """Called by can.Notifier in a background thread for each received message."""
         if msg.arbitration_id == STATUS_ID:
@@ -104,6 +105,19 @@ class ECommsNode(Node):
             else:
                 self.logger.warning("CAN message received before executor ready, dropping frame")
 
+    def handle_status_msg(self, msg_data: bytes):
+        try:
+            self.adcb_status = e_comms.unpack_status_message(msg_data, self.logger)
+
+            self.adcb_state_pub.publish(String(data=self.adcb_status.logic_mode))
+            self.rc_mode_pub.publish(Bool(data=self.adcb_status.rc_mode))
+            self.throttle_pwm_pub.publish(UInt16(data=self.adcb_status.throttle_pwm))
+            self.steering_pwm_pub.publish(UInt16(data=self.adcb_status.steering_pwm))
+        except Exception as e:
+            self.logger.error(f"Failed to parse CAN message: {e}")
+    #--------------------------------------------------------------------------#
+
+    # Command Callbacks -------------------------------------------------------#
     def cmd_thr(self, throttle_msg: Float32):
         self.cmd_count += 1
         if not (0.0 <= throttle_msg.data <= 100.0):
@@ -119,7 +133,9 @@ class ECommsNode(Node):
             self.steering_angle = 0.0  # Default to straight if invalid command
             return
         self.steering_angle = steering_msg.data
-
+    #--------------------------------------------------------------------------#
+    
+    # CAN TX ------------------------------------------------------------------#
     def on_timer(self):
         tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle, self.logger)
         # self.logger.info(f"Steering: {steering_msg.data}")
@@ -136,17 +152,7 @@ class ECommsNode(Node):
                 self.bus.send(msg)
             except can.CanError as e:
                 self.logger.error(f"Failed to send CAN message: {e}")
-
-    def handle_status_msg(self, msg_data: bytes):
-        try:
-            self.adcb_status = e_comms.unpack_status_message(msg_data, self.logger)
-
-            self.adcb_state_pub.publish(String(data=self.adcb_status.logic_mode))
-            self.rc_mode_pub.publish(Bool(data=self.adcb_status.rc_mode))
-            self.throttle_pwm_pub.publish(UInt16(data=self.adcb_status.throttle_pwm))
-            self.steering_pwm_pub.publish(UInt16(data=self.adcb_status.steering_pwm))
-        except Exception as e:
-            self.logger.error(f"Failed to parse CAN message: {e}")
+    #--------------------------------------------------------------------------#
 
     def destroy_node(self):
         # Close CAN

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -137,7 +137,7 @@ class ECommsNode(Node):
         self.steering_angle = steering_msg.data
         self.last_command_time = self.get_clock().now()
     #--------------------------------------------------------------------------#
-    
+
     # CAN TX ------------------------------------------------------------------#
     def can_tx(self):
         """

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -68,18 +68,14 @@ class ECommsNode(Node):
         # Timer to log average every 5 seconds
         self.create_timer(5.0, self.log_command_rate)
 
-        # Subscribe to pathfinder node for throttle and steering commands
-        # self.throttle_sub: Subscriber = Subscriber(self, Float32, "cmd_vel")
-        # self.steering_sub: Subscriber = Subscriber(self, Float32, "cmd_turn")
-        # self.ts: ApproximateTimeSynchronizer = ApproximateTimeSynchronizer(
-        #     [self.throttle_sub, self.steering_sub],
-        #     queue_size=3,
-        #     slop=0.01,  # Time tolerance in seconds
-        #     allow_headerless=True,  # Float32 has no header
-        # )
-        # self.ts.registerCallback(self.cmd_callback)
+        # Subscribe for throttle and steering commands
+        # Each command updates the internal state, and the latest values are sent out on the CAN bus at a fixed rate in on_timer()
         self.steering_sub = self.create_subscription(Float32, "cmd_turn", self.cmd_steer, 5)
         self.throttle_sub = self.create_subscription(Float32, "cmd_vel", self.cmd_thr, 5)
+
+        # CAN TX timer at 20Hz to send latest command values
+        self.timer = self.create_timer(1.0 / 10.0, self.on_timer)
+
 
         # Publishers
         self.adcb_state_pub = self.create_publisher(
@@ -95,83 +91,24 @@ class ECommsNode(Node):
             UInt16, "e_comms/steering_pwm", 1
         )
 
-        self.timer = self.create_timer(1.0 / 10.0, self.on_timer)
-
         # Init finished
         self.logger.info("Initialize EComms Node")
 
     def cmd_thr(self, throttle_msg: Float32):
-        """
-        Send the throttle and steering command to the Electrical Stack via CAN.
-        Part of hot loop so must be efficient
-
-        :param throttle_msg: Float32 message for throttle command (percent throttle)
-        :param steering_msg: Float32 message for steering command (percent steering, -100 to 100)
-        :return: None
-        """
         self.cmd_count += 1
-
-        # Ensure values are within expected ranges
         if not (0.0 <= throttle_msg.data <= 100.0):
-            self.logger.error(
-                f"Received out-of-bounds command values: "
-                f"throttle_percent={throttle_msg.data}, steering_angle={self.steering_angle}"
-            )
-            raise ValueError("Command values out of bounds")
-
+            self.logger.error(f"Received out-of-bounds throttle command: {throttle_msg.data}.")
+            self.throttle_percent = 0.0  # Default to zero if invalid command
+            return
         self.throttle_percent = throttle_msg.data
-        tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle, self.logger)
-
-        if self.bus is not None:
-            msg = can.Message(
-                arbitration_id=CONTROL_ID,
-                data=tx_data,
-                is_extended_id=False,
-            )
-            try:
-                self.bus.send(msg)
-                self.logger.info(f"Sent CAN: {msg.data.hex()}")
-            except can.CanError as e:
-                self.logger.error(f"Failed to send CAN message: {e}")
-
 
     def cmd_steer(self, steering_msg: Float32):
-        """
-        Send the throttle and steering command to the Electrical Stack via CAN.
-        Part of hot loop so must be efficient
-
-        :param throttle_msg: Float32 message for throttle command (percent throttle)
-        :param steering_msg: Float32 message for steering command (percent steering, -100 to 100)
-        :return: None
-        """
         self.cmd_count += 1
-
-        # Ensure values are within expected ranges
-        if not (
-                -100.0 <= steering_msg.data <= 100.0
-        ):
-            self.logger.error(
-                f"Received out-of-bounds command values: "
-                f"throttle_percent={self.throttle_percent}, steering_angle={steering_msg.data}"
-            )
-            raise ValueError("Command values out of bounds")
-
+        if not (-100.0 <= steering_msg.data <= 100.0):
+            self.logger.error(f"Received out-of-bounds steering command: {steering_msg.data}.")
+            self.steering_angle = 0.0  # Default to straight if invalid command
+            return
         self.steering_angle = steering_msg.data
-        tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle, self.logger)
-        self.logger.info(f"Steering: {steering_msg.data}")
-        for i, hx in enumerate(list(tx_data)):
-            self.logger.info(f"{i}: {hx}")
-        self.logger.info(f"tx_data: {tx_data}")
-        if self.bus is not None:
-            msg = can.Message(
-                arbitration_id=CONTROL_ID,
-                data=tx_data,
-                is_extended_id=False,
-            )
-            try:
-                self.bus.send(msg)
-            except can.CanError as e:
-                self.logger.error(f"Failed to send CAN message: {e}")
 
     def _on_can_msg(self, msg: can.Message):
         """Called by can.Notifier in a background thread for each received message."""

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -8,7 +8,6 @@ from rclpy.node import Node
 from rclpy.time import Time
 from std_msgs.msg import Float32, UInt16, Bool, String
 from rclpy.impl.rcutils_logger import RcutilsLogger
-from message_filters import Subscriber, ApproximateTimeSynchronizer
 
 import autonomous_kart.nodes.e_comms.e_comms as e_comms
 

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -94,6 +94,16 @@ class ECommsNode(Node):
         # Init finished
         self.logger.info("Initialize EComms Node")
 
+    def _on_can_msg(self, msg: can.Message):
+        """Called by can.Notifier in a background thread for each received message."""
+        if msg.arbitration_id == STATUS_ID:
+            data = bytes(msg.data)  # copy, don't hold a reference
+            # Add to executor to handle in main thread because ros publishers are not thread safe
+            if self.executor is not None:
+                self.executor.create_task(lambda: self.handle_status_msg(data))
+            else:
+                self.logger.warning("CAN message received before executor ready, dropping frame")
+
     def cmd_thr(self, throttle_msg: Float32):
         self.cmd_count += 1
         if not (0.0 <= throttle_msg.data <= 100.0):
@@ -109,16 +119,6 @@ class ECommsNode(Node):
             self.steering_angle = 0.0  # Default to straight if invalid command
             return
         self.steering_angle = steering_msg.data
-
-    def _on_can_msg(self, msg: can.Message):
-        """Called by can.Notifier in a background thread for each received message."""
-        if msg.arbitration_id == STATUS_ID:
-            data = bytes(msg.data)  # copy, don't hold a reference
-            # Add to executor to handle in main thread because ros publishers are not thread safe
-            if self.executor is not None:
-                self.executor.create_task(lambda: self.handle_status_msg(data))
-            else:
-                self.logger.warning("CAN message received before executor ready, dropping frame")
 
     def on_timer(self):
         tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle, self.logger)


### PR DESCRIPTION
- In manual mode, commands are not sent at a fixed rate
- Remove `ApproximateTimeSynchronizer` system
- Instead callbacks for `"cmd_vel"` and `"cmd_turn"` only set internal state and a timer-ed callback is used to send CAN commands out at a fixed rate
- If no `"cmd_vel"` and `"cmd_turn"` commands have been seen by E_COMMS in over a second, it reverts the state back to defaults/zeros (straight, no throttle)