### PR TITLE
E_Comms heartbeat system

### DIFF
--- a/src/autonomous_kart/autonomous_kart/launch/bringup_pi.launch.py
+++ b/src/autonomous_kart/autonomous_kart/launch/bringup_pi.launch.py
@@ -18,6 +18,7 @@ def generate_launch_description():
     pathfinder_yaml = os.path.join(pkg_share, "params", "pathfinder.yaml")
     localization_yaml = os.path.join(pkg_share, "params", "localization.yaml")
     imu_yaml = os.path.join(pkg_share, "params", "imu.yaml")
+    e_comms_yaml = os.path.join(pkg_share, "params", "e_comms.yaml")
 
     sim_mode = LaunchConfiguration("simulation_mode")
 
@@ -78,6 +79,7 @@ def generate_launch_description():
                         package="autonomous_kart",
                         executable="e_comms_node",
                         name="e_comms_node",
+                        parameters=[e_comms_yaml],
                     ),
                     Node(
                         package="autonomous_kart",

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -69,8 +69,8 @@ def pack_hb_message(counter: int) -> bytes:
     Pack a heartbeat message with a simple counter.
 
     - ID = `0x102` - **E_Comms heartbeat** (RX)
-	    - Byte 0: E_Comms heartbeat counter (uint8_t)
-	    - Byte 1-7: reserved / future use
+        - Byte 0: E_Comms heartbeat counter (uint8_t)
+        - Byte 1-7: reserved / future use
 
     :param counter: Heartbeat counter (does not have to be 0-255, will be truncated to uint8_t)
     :return: byte array of length 8.

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -63,6 +63,28 @@ def pack_control_message(throttle_percent: float, steering_angle: float) -> byte
 
     return bytes(data)
 
+
+def pack_hb_message(counter: int) -> bytes:
+    """
+    Pack a heartbeat message with a simple counter.
+
+    - ID = `0x102` - **E_Comms heartbeat** (RX)
+	    - Byte 0: E_Comms heartbeat counter (uint8_t)
+	    - Byte 1-7: reserved / future use
+
+    :param counter: Heartbeat counter (does not have to be 0-255, will be truncated to uint8_t)
+    :return: byte array of length 8.
+    """
+    data = bytearray(8)
+    data[0] = counter & 0xFF  # Truncate to uint8_t
+
+    # bytes 1-7 reserved for future use, set to 0
+    for i in range(1, 8):
+        data[i] = 0
+
+    return bytes(data)
+
+
 def unpack_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus:
     """
     Unpack the throttle feedback from the received CAN buffer.

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -69,11 +69,10 @@ class ECommsNode(Node):
         self.create_timer(5.0, self.log_command_rate)
 
         # Subscribe for throttle and steering commands
-        # Each command updates the internal state, and the latest values are sent
-        # out on the CAN bus at a fixed rate in can_tx()
+        # Each command updates the internal state and then calls can_control_tx to send
+        # the latest command on the CAN bus immediately
         self.steering_sub = self.create_subscription(Float32, "cmd_turn", self.cmd_steer, 5)
         self.throttle_sub = self.create_subscription(Float32, "cmd_vel", self.cmd_thr, 5)
-        self.last_command_time = self.get_clock().now()
 
         # CAN heartbeat
         self.hb_counter = 0
@@ -128,7 +127,7 @@ class ECommsNode(Node):
             self.throttle_percent = 0.0  # Default to zero if invalid command
             return
         self.throttle_percent = throttle_msg.data
-        self.last_command_time = self.get_clock().now()
+        self.can_control_tx()  # Send updated command immediately on CAN bus
 
     def cmd_steer(self, steering_msg: Float32):
         self.cmd_count += 1
@@ -137,7 +136,7 @@ class ECommsNode(Node):
             self.steering_angle = 0.0  # Default to straight if invalid command
             return
         self.steering_angle = steering_msg.data
-        self.last_command_time = self.get_clock().now()
+        self.can_control_tx()  # Send updated command immediately on CAN bus
     #--------------------------------------------------------------------------#
 
     # CAN TX ------------------------------------------------------------------#
@@ -160,17 +159,11 @@ class ECommsNode(Node):
             except can.CanError as e:
                 self.logger.error(f"Failed to send CAN heartbeat message: {e}")
 
-    def can_tx(self):
+    def can_control_tx(self):
         """
-        Send the latest throttle and steering commands on the CAN bus at a fixed rate.
-        If we have not received any new commands for a while (1 sec) reset to default/zero commands instead.
+        Send the latest throttle and steering commands on the CAN bus.
+        Uses internal state updated by the command callbacks.
         """
-        # if (self.get_clock().now() - self.last_command_time).nanoseconds / 1e9 > 1.0:
-        #     # No recent commands, default to zero
-        #     self.throttle_percent = 0.0
-        #     self.steering_angle = 0.0
-        #     # TODO: make the 1 sec timeout a parameter
-
         tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle)
         if self.bus is not None:
             msg = can.Message(

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -16,6 +16,7 @@ CAN_BITRATE = 500000
 
 CONTROL_ID = 0x100
 STATUS_ID = 0x101
+HEARTBEAT_ID = 0x102
 
 
 class ECommsNode(Node):
@@ -74,9 +75,10 @@ class ECommsNode(Node):
         self.throttle_sub = self.create_subscription(Float32, "cmd_vel", self.cmd_thr, 5)
         self.last_command_time = self.get_clock().now()
 
-        # CAN TX timer at 50Hz to send latest command values
-        # TODO: make a parameter
-        self.timer = self.create_timer(1.0 / 50.0, self.can_tx)
+        # CAN heartbeat
+        self.hb_counter = 0
+        self.timer = self.create_timer(1.0 / 10.0, self.can_hb_tx)
+        # TODO: make heartbeat rate a parameter
 
         # Publishers
         self.adcb_state_pub = self.create_publisher(
@@ -139,6 +141,25 @@ class ECommsNode(Node):
     #--------------------------------------------------------------------------#
 
     # CAN TX ------------------------------------------------------------------#
+    def can_hb_tx(self):
+        """
+        Send heartbeat message on CAN bus at a fixed rate.
+        Also updates the heartbeat counter which is included in the message payload.
+        """
+        self.hb_counter = (self.hb_counter + 1) % 256  # Wrap around at 255
+        hb_data = e_comms.pack_hb_message(self.hb_counter)
+
+        if self.bus is not None:
+            msg = can.Message(
+                arbitration_id=HEARTBEAT_ID,
+                data=hb_data,
+                is_extended_id=False,
+            )
+            try:
+                self.bus.send(msg)
+            except can.CanError as e:
+                self.logger.error(f"Failed to send CAN heartbeat message: {e}")
+
     def can_tx(self):
         """
         Send the latest throttle and steering commands on the CAN bus at a fixed rate.

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -80,21 +80,13 @@ class ECommsNode(Node):
         # TODO: make heartbeat rate a parameter
 
         # Publishers
-        self.adcb_state_pub = self.create_publisher(
-            String, "e_comms/adcb_state", 1
-        )
-        self.rc_mode_pub = self.create_publisher(
-            Bool, "e_comms/rc_mode", 1
-        )
-        self.throttle_pwm_pub = self.create_publisher(
-            UInt16, "e_comms/throttle_pwm", 1
-        )
-        self.steering_pwm_pub = self.create_publisher(
-            UInt16, "e_comms/steering_pwm", 1
-        )
+        self.adcb_state_pub = self.create_publisher(String, "e_comms/adcb_state", 1)
+        self.rc_mode_pub = self.create_publisher(Bool, "e_comms/rc_mode", 1)
+        self.throttle_pwm_pub = self.create_publisher(UInt16, "e_comms/throttle_pwm", 1)
+        self.steering_pwm_pub = self.create_publisher(UInt16, "e_comms/steering_pwm", 1)
 
         # Init finished
-        self.logger.info("Initialize EComms Node")
+        self.logger.info("Initialized EComms Node")
 
     # CAN RX ------------------------------------------------------------------#
     def _on_can_msg(self, msg: can.Message):

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -76,8 +76,8 @@ class ECommsNode(Node):
 
         # CAN heartbeat
         self.hb_counter = 0
-        self.timer = self.create_timer(1.0 / 10.0, self.can_hb_tx)
-        # TODO: make heartbeat rate a parameter
+        self.hb_tx_period_ms = self.get_parameter("heartbeat_period_ms").value
+        self.hb_timer = self.create_timer(self.hb_tx_period_ms / 1000.0, self.can_hb_tx)
 
         # Publishers
         self.adcb_state_pub = self.create_publisher(String, "e_comms/adcb_state", 1)

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -117,8 +117,8 @@ class ECommsNode(Node):
         if not (0.0 <= throttle_msg.data <= 100.0):
             self.logger.error(f"Received out-of-bounds throttle command: {throttle_msg.data}.")
             self.throttle_percent = 0.0  # Default to zero if invalid command
-            return
-        self.throttle_percent = throttle_msg.data
+        else:
+            self.throttle_percent = throttle_msg.data
         self.can_control_tx()  # Send updated command immediately on CAN bus
 
     def cmd_steer(self, steering_msg: Float32):
@@ -126,8 +126,8 @@ class ECommsNode(Node):
         if not (-100.0 <= steering_msg.data <= 100.0):
             self.logger.error(f"Received out-of-bounds steering command: {steering_msg.data}.")
             self.steering_angle = 0.0  # Default to straight if invalid command
-            return
-        self.steering_angle = steering_msg.data
+        else:
+            self.steering_angle = steering_msg.data
         self.can_control_tx()  # Send updated command immediately on CAN bus
     #--------------------------------------------------------------------------#
 

--- a/src/autonomous_kart/autonomous_kart/params/e_comms.yaml
+++ b/src/autonomous_kart/autonomous_kart/params/e_comms.yaml
@@ -1,0 +1,3 @@
+e_comms_node:
+  ros__parameters:
+    heartbeat_period_ms: 100.0


### PR DESCRIPTION
- https://github.com/EVC-Purdue/AutonomousElectrical/pull/12
- 100 ms period send a heartbeat message from E_Comms to ADCB
- Send Control messages immediately on receiving a `"cmd_vel"` or `"cmd_turn"` ROS message
- Note: have to be a little careful, control flow no longer has any timeout
  - If the upstream cmd_vel/cmd_turn stream pauses/crashes/etc ADCB may continue applying the last command indefinitely (or until E_Comms exits => heartbeat ends, or RC override)