### PR TITLE
E_Comms: VESC CAN

### DIFF
--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -37,26 +37,25 @@ class VescCanStatus1:
     duty_cycle: int   # Duty cycle in 0.001 (e.g., 1000 = 100%)
 
 
-def pack_control_message(throttle_percent: float, steering_angle: float) -> bytes:
+def pack_control_message(throttle_erpm: int, steering_percent: float) -> bytes:
     """
     Pack the throttle and steering commands into a bytearray buffer for CAN
     Caller is responsible for ensuring values are within expected ranges.
 
     - ID = 0x100 - **Control commands**
-        - Byte 0-1: throttle (uint16_t, little endian), 0-1000, where 1000 = full throttle
-        - Byte 2-3: steering (uint16_t, little endian), 0-1000, where 500 = straight, 0 = full left, 1000 = full right
+        - Byte 0-1: throttle ERPM (uint16_t, little endian), 0-AUTONOMOUS_ERPM_MAX (0 = full stop, AUTONOMOUS_ERPM_MAX = max speed)
+        - Byte 2-3: steering representation (uint16_t, little endian), 0-1000, where 500 = straight, 0 = full left, 1000 = full right
         - Byte 4-7: reserved / future use
         
     :param throttle_percent: throttle command as a percentage (0 to 100)
     :param steering_angle: Steering command as percent steering (-100 to 100, 0 = center)
     :return: byte array of length 8.
     """
-    throttle = int(1000 * (throttle_percent / 100.0))  # 0-1000
-    steering = int(500 + 500 * (steering_angle / 100.0))  # -100..100 -> 0..1000
+    steering = int(500 + 500 * (steering_percent / 100.0))  # -100..100 -> 0..1000
 
     data = bytearray(8)
-    data[0] = throttle & 0xFF
-    data[1] = (throttle >> 8) & 0xFF
+    data[0] = throttle_erpm & 0xFF
+    data[1] = (throttle_erpm >> 8) & 0xFF
 
     data[2] = steering & 0xFF
     data[3] = (steering >> 8) & 0xFF

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -138,8 +138,8 @@ def unpack_vesc_status_1_message(data: bytes, logger: RcutilsLogger) -> VescCanS
         logger.error(f"VESC status message data length invalid: expected 8, got {len(data)}")
         raise ValueError(f"VESC status message data length invalid: expected 8, got {len(data)}")
     
-    erpm = (int(data[0]) << 24) | (int(data[1]) << 16) | (int(data[2]) << 8) | int(data[3])
-    current = (int(data[4]) << 8) | int(data[5])
-    duty_cycle = (int(data[6]) << 8) | int(data[7])
+    erpm = int.from_bytes(data[0:4], byteorder="big", signed=True)
+    current = int.from_bytes(data[4:6], byteorder="big", signed=True)
+    duty_cycle = int.from_bytes(data[6:8], byteorder="big", signed=True)
 
     return VescCanStatus1(erpm, current, duty_cycle)

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -85,9 +85,9 @@ def pack_hb_message(counter: int) -> bytes:
     return bytes(data)
 
 
-def unpack_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus:
+def unpack_adcb_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus:
     """
-    Unpack the throttle feedback from the received CAN buffer.
+    Unpack the Autonomous Distro/Control Board (ADCB) status message received from the CAN bus.
 
     - ID = 0x101 - **Status update** (TX)
         - Byte 0: state machine mode + rc mode

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -30,6 +30,12 @@ class AdcbStatus:
     throttle_pwm: int # Integer value of the throttle PWM (1000-2000)
     steering_pwm: int # Integer value of the steering PWM (1000-2000)
 
+@dataclass
+class VescCanStatus1:
+    erpm: int         # ERPM of the motor
+    current: int      # Motor current in 0.1A (e.g., 100 = 10A)
+    duty_cycle: int   # Duty cycle in 0.001 (e.g., 1000 = 100%)
+
 
 def pack_control_message(throttle_percent: float, steering_angle: float) -> bytes:
     """

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -116,4 +116,25 @@ def unpack_adcb_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus
 
     return AdcbStatus(logic_mode_str, rc_mode_bool, throttle_pwm, steering_pwm)
 
+def unpack_vesc_status_1_message(data: bytes, logger: RcutilsLogger) -> VescCanStatus1:
+    """
+    Unpack the VESC status message 1 received from the CAN bus.
+
+    - ID = `CAN_VESC_MSG_NUM_TO_EXT_ID(9 = CAN_VESC_STATUS_1_MSG_NUM)` (ext id) - **VESC status 1** (RX)
+        - Byte 0-3: VESC ERPM (BE)
+        - Byte 4-5: VESC current (in 0.1A, so 100 = 10A) (BE)
+        - Byte 6-7: VESC duty cycle (in 0.001, so 1000 = 100%) (BE)
+
+    :param data: byte array of length 8 received from CAN message
+    :param logger: Logger for logging errors
+    :return: A VescCanStatus1 object containing the unpacked data
+    """
+    if len(data) != 8:
+        logger.error(f"VESC status message data length invalid: expected 8, got {len(data)}")
+        raise ValueError(f"VESC status message data length invalid: expected 8, got {len(data)}")
     
+    erpm = (int(data[0]) << 24) | (int(data[1]) << 16) | (int(data[2]) << 8) | int(data[3])
+    current = (int(data[4]) << 8) | int(data[5])
+    duty_cycle = (int(data[6]) << 8) | int(data[7])
+
+    return VescCanStatus1(erpm, current, duty_cycle)

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -14,9 +14,14 @@ import autonomous_kart.nodes.e_comms.e_comms as e_comms
 CAN_CHANNEL = "/dev/ttyACM0"
 CAN_BITRATE = 500000
 
+VESC_ID = 7
+VESC_STATUS_1_MSG_NUM = 9
+VESC_MSG_NUM_TO_EXT_ID = lambda msg_num: ((msg_num << 8) | VESC_ID)
+
 CONTROL_ID = 0x100
 STATUS_ID = 0x101
 HEARTBEAT_ID = 0x102
+VESC_STATUS_1_ID = VESC_MSG_NUM_TO_EXT_ID(VESC_STATUS_1_MSG_NUM)
 
 
 class ECommsNode(Node):

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -56,6 +56,11 @@ class ECommsNode(Node):
             throttle_pwm=0,
             steering_pwm=0,
         )
+        self.vesc_status_1: e_comms.VescCanStatus1 = e_comms.VescCanStatus1(
+            erpm=0,
+            current=0,
+            duty_cycle=0,
+        )
 
         # CAN bus
         if not self.simulation_mode:
@@ -130,8 +135,8 @@ class ECommsNode(Node):
 
     def handle_vesc_status_1_msg(self, msg_data: bytes):
         try:
-            vesc_status_1 = e_comms.unpack_vesc_status_1_message(msg_data, self.logger)
-            speed_m_per_s = powertrain.erpm_to_speed(vesc_status_1.erpm)
+            self.vesc_status_1 = e_comms.unpack_vesc_status_1_message(msg_data, self.logger)
+            speed_m_per_s = powertrain.erpm_to_speed(self.vesc_status_1.erpm)
             self.speed_pub.publish(Float32(data=speed_m_per_s))
         except Exception as e:
             self.logger.error(f"Failed to parse VESC status message: {e}")

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -128,6 +128,8 @@ class ECommsNode(Node):
 
     def handle_vesc_status_1_msg(self, msg_data: bytes):
         try:
+            vesc_status_1 = e_comms.unpack_vesc_status_1_message(msg_data, self.logger)
+            speed_m_per_s = powertrain.erpm_to_speed(vesc_status_1.erpm)
         except Exception as e:
             self.logger.error(f"Failed to parse VESC status message: {e}")
     #--------------------------------------------------------------------------#

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -46,8 +46,8 @@ class ECommsNode(Node):
         self.steer_max_deg: float = float(self.get_parameter("steer_max_deg").value)
 
         # Inputs
-        self.throttle_percent: float = 0.0
-        self.steering_angle: float = 0.0
+        self.throttle_erpm: float = 0.0
+        self.steering_percent: float = 0.0
 
         # Outputs
         self.adcb_status: e_comms.AdcbStatus = e_comms.AdcbStatus(
@@ -148,25 +148,19 @@ class ECommsNode(Node):
         if len(msg.data) < 2:
             self.logger.error(f"cmd_drive payload too short: {list(msg.data)}")
             return
-        self.steering_angle, self.throttle_percent = self.convert(
-            float(msg.data[1]), float(msg.data[0]),
-        )
+        throttle_cmd = msg.data[0] # m/s
+        steering_cmd = msg.data[1] # degrees (negative = left, positive = right)
+        self.throttle_erpm, self.steering_percent = self.convert(throttle_cmd, steering_cmd)
         self.can_control_tx()  # Send updated command immediately on CAN bus
 
-    def convert(self, steering: float, throttle: float) -> tuple:
+    def convert(self, throttle_m_per_s: float, steering_deg: float) -> tuple[float, float]:
         """Clamp + unit-convert (steering, throttle) for the CAN control frame."""
-        throttle = throttle * 3
-        if throttle < self.min_speed:
-            throttle = self.min_speed
-        elif throttle > self.max_speed:
-            throttle = self.max_speed
+        clamped_throttle_m_per_s = max(self.min_speed, min(self.max_speed, throttle_m_per_s))
+        throttle_erpm = powertrain.speed_to_erpm(clamped_throttle_m_per_s)
 
-        steering = (steering / self.steer_max_deg) * 100.0 * 2.0
-        if steering < self.min_steering:
-            steering = self.min_steering
-        elif steering > self.max_steering:
-            steering = self.max_steering
-        return steering, throttle
+        clamped_steering_deg = max(self.min_steering, min(self.steer_max_deg, steering_deg))
+        steering_percent = (clamped_steering_deg / self.steer_max_deg) * 100.0
+        return throttle_erpm, steering_percent
     #--------------------------------------------------------------------------#
 
     # CAN TX ------------------------------------------------------------------#

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -189,7 +189,7 @@ class ECommsNode(Node):
         Send the latest throttle and steering commands on the CAN bus.
         Uses internal state updated by the command callbacks.
         """
-        tx_data = e_comms.pack_control_message(self.throttle_percent, self.steering_angle)
+        tx_data = e_comms.pack_control_message(self.throttle_erpm, self.steering_percent)
         if self.bus is not None:
             msg = can.Message(
                 arbitration_id=CONTROL_ID,

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -114,7 +114,7 @@ class ECommsNode(Node):
 
     def handle_status_msg(self, msg_data: bytes):
         try:
-            self.adcb_status = e_comms.unpack_status_message(msg_data, self.logger)
+            self.adcb_status = e_comms.unpack_adcb_status_message(msg_data, self.logger)
 
             self.adcb_state_pub.publish(String(data=self.adcb_status.logic_mode))
             self.rc_mode_pub.publish(Bool(data=self.adcb_status.rc_mode))

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -104,15 +104,18 @@ class ECommsNode(Node):
     # CAN RX ------------------------------------------------------------------#
     def _on_can_msg(self, msg: can.Message):
         """Called by can.Notifier in a background thread for each received message."""
+        if self.executor is None:
+            self.logger.warning("CAN message received before executor ready, dropping frame")
+            return
+        
+        data = bytes(msg.data)  # copy, don't hold a reference
+        
         if msg.arbitration_id == STATUS_ID:
-            data = bytes(msg.data)  # copy, don't hold a reference
-            # Add to executor to handle in main thread because ros publishers are not thread safe
-            if self.executor is not None:
-                self.executor.create_task(lambda: self.handle_status_msg(data))
-            else:
-                self.logger.warning("CAN message received before executor ready, dropping frame")
+            self.executor.create_task(lambda: self.handle_adcb_status_msg(data))
+        elif msg.arbitration_id == VESC_STATUS_1_ID:
+            self.executor.create_task(lambda: self.handle_vesc_status_1_msg(data))
 
-    def handle_status_msg(self, msg_data: bytes):
+    def handle_adcb_status_msg(self, msg_data: bytes):
         try:
             self.adcb_status = e_comms.unpack_adcb_status_message(msg_data, self.logger)
 
@@ -122,6 +125,11 @@ class ECommsNode(Node):
             self.steering_pwm_pub.publish(UInt16(data=self.adcb_status.steering_pwm))
         except Exception as e:
             self.logger.error(f"Failed to parse CAN message: {e}")
+
+    def handle_vesc_status_1_msg(self, msg_data: bytes):
+        try:
+        except Exception as e:
+            self.logger.error(f"Failed to parse VESC status message: {e}")
     #--------------------------------------------------------------------------#
 
     # Command Callbacks -------------------------------------------------------#

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -159,7 +159,8 @@ class ECommsNode(Node):
         throttle_erpm = powertrain.speed_to_erpm(clamped_throttle_m_per_s)
 
         clamped_steering_deg = max(self.min_steering, min(self.steer_max_deg, steering_deg))
-        steering_percent = (clamped_steering_deg / self.steer_max_deg) * 100.0
+        max_one_direction_steering = max(abs(self.min_steering), abs(self.steer_max_deg))
+        steering_percent = (clamped_steering_deg / max_one_direction_steering) * 100.0
         return throttle_erpm, steering_percent
     #--------------------------------------------------------------------------#
 

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -103,7 +103,7 @@ class ECommsNode(Node):
         self.rc_mode_pub = self.create_publisher(Bool, "e_comms/rc_mode", 1)
         self.throttle_pwm_pub = self.create_publisher(UInt16, "e_comms/throttle_pwm", 1)
         self.steering_pwm_pub = self.create_publisher(UInt16, "e_comms/steering_pwm", 1)
-        self.speed_pub = self.create_publisher(Float32, "e_comms/wheel_speed", 1)
+        self.speed_pub = self.create_publisher(Float32, "e_comms/kart_speed_m_per_s", 1)
 
         # Init finished
         self.logger.info("Initialized EComms Node")

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -6,10 +6,11 @@ import can
 import rclpy
 from rclpy.node import Node
 from rclpy.time import Time
-from std_msgs.msg import Float32MultiArray, UInt16, Bool, String
+from std_msgs.msg import Float32MultiArray, UInt16, Bool, String, Float32
 from rclpy.impl.rcutils_logger import RcutilsLogger
 
 import autonomous_kart.nodes.e_comms.e_comms as e_comms
+import autonomous_kart.nodes.e_comms.powertrain as powertrain
 
 CAN_CHANNEL = "/dev/ttyACM0"
 CAN_BITRATE = 500000
@@ -97,6 +98,7 @@ class ECommsNode(Node):
         self.rc_mode_pub = self.create_publisher(Bool, "e_comms/rc_mode", 1)
         self.throttle_pwm_pub = self.create_publisher(UInt16, "e_comms/throttle_pwm", 1)
         self.steering_pwm_pub = self.create_publisher(UInt16, "e_comms/steering_pwm", 1)
+        self.speed_pub = self.create_publisher(Float32, "e_comms/wheel_speed", 1)
 
         # Init finished
         self.logger.info("Initialized EComms Node")
@@ -130,6 +132,7 @@ class ECommsNode(Node):
         try:
             vesc_status_1 = e_comms.unpack_vesc_status_1_message(msg_data, self.logger)
             speed_m_per_s = powertrain.erpm_to_speed(vesc_status_1.erpm)
+            self.speed_pub.publish(Float32(data=speed_m_per_s))
         except Exception as e:
             self.logger.error(f"Failed to parse VESC status message: {e}")
     #--------------------------------------------------------------------------#
@@ -247,3 +250,4 @@ def main(args=None):
 
 if __name__ == "__main__":
     main()
+

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/powertrain.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/powertrain.py
@@ -1,0 +1,13 @@
+"""
+- Teeth on motor gear: 15
+- Teeth on axle gear: 65
+- Wheel diameter: 11 inches
+- Pole pairs: 4
+- RPM = ERPM / pole_pairs
+- Speed(ERPM) in m/s =
+	- Axle RPM * Wheel Circumference = 
+	- (Motor RPM * gear_ratio) * (pi * wheel_diameter) =
+	- (ERPM/pole_pairs * gear_ratio) * (pi * wheel_diameter) =
+	- ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter) =
+	- ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter_inches) * (1 meter / 39.37 inches) * (1 minute / 60 seconds)
+"""

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/powertrain.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/powertrain.py
@@ -11,3 +11,33 @@
 	- ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter) =
 	- ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter_inches) * (1 meter / 39.37 inches) * (1 minute / 60 seconds)
 """
+import math
+
+TEETH_ON_MOTOR_GEAR = 15
+TEETH_ON_AXLE_GEAR = 65
+WHEEL_DIAMETER_INCHES = 11
+POLE_PAIRS = 4
+GEAR_RATIO = TEETH_ON_MOTOR_GEAR / TEETH_ON_AXLE_GEAR
+WHEEL_CIRCUMFERENCE_INCHES = (math.pi * WHEEL_DIAMETER_INCHES)
+INCHES_TO_METERS = 1 / 39.37
+SECONDS_PER_MINUTE = 60.0
+
+def erpm_to_speed(erpm: float) -> float:
+	"""
+	Convert ERPM (Electrical RPM) to linear speed in m/s.
+	"""
+	motor_rpm = erpm / POLE_PAIRS
+	axle_rpm = motor_rpm * GEAR_RATIO
+	wheel_circumference_meters = WHEEL_CIRCUMFERENCE_INCHES * INCHES_TO_METERS
+	speed_m_per_s = (axle_rpm * wheel_circumference_meters) / SECONDS_PER_MINUTE
+	return speed_m_per_s
+
+def speed_to_erpm(speed_m_per_s: float) -> float:
+	"""
+	Convert linear speed in m/s to ERPM (Electrical RPM).
+	"""
+	wheel_circumference_meters = WHEEL_CIRCUMFERENCE_INCHES * INCHES_TO_METERS
+	axle_rpm = (speed_m_per_s * SECONDS_PER_MINUTE) / wheel_circumference_meters
+	motor_rpm = axle_rpm / GEAR_RATIO
+	erpm = motor_rpm * POLE_PAIRS
+	return erpm

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/powertrain.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/powertrain.py
@@ -5,11 +5,11 @@
 - Pole pairs: 4
 - RPM = ERPM / pole_pairs
 - Speed(ERPM) in m/s =
-	- Axle RPM * Wheel Circumference = 
-	- (Motor RPM * gear_ratio) * (pi * wheel_diameter) =
-	- (ERPM/pole_pairs * gear_ratio) * (pi * wheel_diameter) =
-	- ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter) =
-	- ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter_inches) * (1 meter / 39.37 inches) * (1 minute / 60 seconds)
+    - Axle RPM * Wheel Circumference = 
+    - (Motor RPM * gear_ratio) * (pi * wheel_diameter) =
+    - (ERPM/pole_pairs * gear_ratio) * (pi * wheel_diameter) =
+    - ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter) =
+    - ((ERPM/pole_pairs) * (teeth_on_motor_gear/teeth_on_axle_gear) * (pi * wheel_diameter_inches) * (1 meter / 39.37 inches) * (1 minute / 60 seconds)
 """
 import math
 
@@ -23,21 +23,21 @@ INCHES_TO_METERS = 1 / 39.37
 SECONDS_PER_MINUTE = 60.0
 
 def erpm_to_speed(erpm: float) -> float:
-	"""
-	Convert ERPM (Electrical RPM) to linear speed in m/s.
-	"""
-	motor_rpm = erpm / POLE_PAIRS
-	axle_rpm = motor_rpm * GEAR_RATIO
-	wheel_circumference_meters = WHEEL_CIRCUMFERENCE_INCHES * INCHES_TO_METERS
-	speed_m_per_s = (axle_rpm * wheel_circumference_meters) / SECONDS_PER_MINUTE
-	return speed_m_per_s
+    """
+    Convert ERPM (Electrical RPM) to linear speed in m/s.
+    """
+    motor_rpm = erpm / POLE_PAIRS
+    axle_rpm = motor_rpm * GEAR_RATIO
+    wheel_circumference_meters = WHEEL_CIRCUMFERENCE_INCHES * INCHES_TO_METERS
+    speed_m_per_s = (axle_rpm * wheel_circumference_meters) / SECONDS_PER_MINUTE
+    return speed_m_per_s
 
 def speed_to_erpm(speed_m_per_s: float) -> float:
-	"""
-	Convert linear speed in m/s to ERPM (Electrical RPM).
-	"""
-	wheel_circumference_meters = WHEEL_CIRCUMFERENCE_INCHES * INCHES_TO_METERS
-	axle_rpm = (speed_m_per_s * SECONDS_PER_MINUTE) / wheel_circumference_meters
-	motor_rpm = axle_rpm / GEAR_RATIO
-	erpm = motor_rpm * POLE_PAIRS
-	return erpm
+    """
+    Convert linear speed in m/s to ERPM (Electrical RPM).
+    """
+    wheel_circumference_meters = WHEEL_CIRCUMFERENCE_INCHES * INCHES_TO_METERS
+    axle_rpm = (speed_m_per_s * SECONDS_PER_MINUTE) / wheel_circumference_meters
+    motor_rpm = axle_rpm / GEAR_RATIO
+    erpm = motor_rpm * POLE_PAIRS
+    return erpm


### PR DESCRIPTION
Units:
- Entire kart stack will be in meters per second for throttle, E_Comms does the final conversion to ERPM
- Entire kart stack will be in degrees for steering, E_Comms does the final conversion to percent

CAN:
- Instead of giving Autonomous Distro/Control Board a percent throttle, it directly gives it a target ERPM, calculated from the m/s
- Support for RX-ing the VESC Status 1 message containing the actual motor ERPM which it then publishes as wheel speed from the ERPM