### PR TITLE
Running mode improvements/alignment to Electrical

### DIFF
--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -118,14 +118,14 @@ def unpack_adcb_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus
         raise ValueError(f"CAN RX data length invalid: expected 8 (or >=5), got {len(data)}")
     
     logic_mode = data[0] & 0x0F      # Bits 0-3
-    rc_mode = (data[0] >> 4) & 0x03  # Bits 4-5
+    running_mode = (data[0] >> 4) & 0x03  # Bits 4-5
     throttle_pwm = int(data[1]) | (int(data[2]) << 8)
     steering_pwm = int(data[3]) | (int(data[4]) << 8)
 
     logic_mode_str = LOGIC_STATE_VALUE_TO_STRING.get(logic_mode, f"UNKNOWN({logic_mode})")
-    rc_mode_str = RUNNING_MODE_VALUE_TO_STRING.get(rc_mode, f"UNKNOWN({rc_mode})")
+    running_mode_str = RUNNING_MODE_VALUE_TO_STRING.get(running_mode, f"UNKNOWN({running_mode})")
 
-    return AdcbStatus(logic_mode_str, rc_mode_str, throttle_pwm, steering_pwm)
+    return AdcbStatus(logic_mode_str, running_mode_str, throttle_pwm, steering_pwm)
 
 def unpack_vesc_status_1_message(data: bytes, logger: RcutilsLogger) -> VescCanStatus1:
     """

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -25,8 +25,8 @@ LOGIC_STATE_VALUE_TO_STRING = {
 
 RUNNING_MODE_VALUE_TO_STRING = {
     0: "RC",
-	1: "AUTONOMOUS",
-	2: "IDLE",
+    1: "AUTONOMOUS",
+    2: "IDLE",
 }
 
 @dataclass

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms.py
@@ -12,7 +12,7 @@ from rclpy.impl.rcutils_logger import RcutilsLogger
 # 	LOGIC_MODE_RECOVERING,
 # } logic_mode_t;
 
-MODE_VALUE_TO_STRING = {
+LOGIC_STATE_VALUE_TO_STRING = {
     0: "STARTING",
     1: "PRECHARGING",
     2: "CONTACTOR_CLOSING",
@@ -23,10 +23,16 @@ MODE_VALUE_TO_STRING = {
     7: "RECOVERING",
 }
 
+RUNNING_MODE_VALUE_TO_STRING = {
+    0: "RC",
+	1: "AUTONOMOUS",
+	2: "IDLE",
+}
+
 @dataclass
 class AdcbStatus:
-    logic_mode: str   # String representation of the state machine mode (e.g., "RUNNING")
-    rc_mode: bool     # Boolean indicating RC mode (True if in autonomous mode, False if in RC mode)
+    logic_state: str  # String representation of the state machine mode (e.g., "RUNNING")
+    running_mode: str # String representation of the running mode (e.g., "AUTONOMOUS")
     throttle_pwm: int # Integer value of the throttle PWM (1000-2000)
     steering_pwm: int # Integer value of the steering PWM (1000-2000)
 
@@ -94,11 +100,11 @@ def unpack_adcb_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus
     """
     Unpack the Autonomous Distro/Control Board (ADCB) status message received from the CAN bus.
 
-    - ID = 0x101 - **Status update** (TX)
+    - ID = `0x101` - **Status update**
         - Byte 0: state machine mode + rc mode
             - Bits0-3 = state machine mode (see logic.h::logic_mode_t)
-            - Bit4 = RC mode (0 = rc mode, 1 = autonomous mode)
-            - Bits5-7 = reserved
+            - Bit4-5 = Mode (0 = RC, 1 = autonomous, 2 = idle)
+            - Bits6-7 = reserved
         - Byte 1-2: throttle PWM (uint16_t, little endian), the actual PWM value being sent to the ESC for throttle (1000-2000)
         - Byte 3-4: steering PWM (uint16_t, little endian), the actual PWM value being sent to the servo for steering (1000-2000)
         - Byte 5-7: reserved / future use
@@ -111,15 +117,15 @@ def unpack_adcb_status_message(data: bytes, logger: RcutilsLogger) -> AdcbStatus
         logger.error(f"CAN RX data length invalid: expected 8 (or >=5), got {len(data)}")
         raise ValueError(f"CAN RX data length invalid: expected 8 (or >=5), got {len(data)}")
     
-    logic_mode = data[0] & 0x0F  # Bits 0-3
-    rc_mode = (data[0] & 0x10) >> 4 # Bit 4
+    logic_mode = data[0] & 0x0F      # Bits 0-3
+    rc_mode = (data[0] >> 4) & 0x03  # Bits 4-5
     throttle_pwm = int(data[1]) | (int(data[2]) << 8)
     steering_pwm = int(data[3]) | (int(data[4]) << 8)
 
-    logic_mode_str = MODE_VALUE_TO_STRING.get(logic_mode, f"UNKNOWN({logic_mode})")
-    rc_mode_bool = bool(rc_mode)
+    logic_mode_str = LOGIC_STATE_VALUE_TO_STRING.get(logic_mode, f"UNKNOWN({logic_mode})")
+    rc_mode_str = RUNNING_MODE_VALUE_TO_STRING.get(rc_mode, f"UNKNOWN({rc_mode})")
 
-    return AdcbStatus(logic_mode_str, rc_mode_bool, throttle_pwm, steering_pwm)
+    return AdcbStatus(logic_mode_str, rc_mode_str, throttle_pwm, steering_pwm)
 
 def unpack_vesc_status_1_message(data: bytes, logger: RcutilsLogger) -> VescCanStatus1:
     """

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -51,8 +51,8 @@ class ECommsNode(Node):
 
         # Outputs
         self.adcb_status: e_comms.AdcbStatus = e_comms.AdcbStatus(
-            logic_mode="not initialized",
-            rc_mode=False,
+            logic_state="not initialized",
+            running_mode="not initialized",
             throttle_pwm=0,
             steering_pwm=0,
         )
@@ -99,8 +99,8 @@ class ECommsNode(Node):
         self.hb_timer = self.create_timer(self.hb_tx_period_ms / 1000.0, self.can_hb_tx)
 
         # Publishers
-        self.adcb_state_pub = self.create_publisher(String, "e_comms/adcb_state", 1)
-        self.rc_mode_pub = self.create_publisher(Bool, "e_comms/rc_mode", 1)
+        self.adcb_state_pub = self.create_publisher(String, "e_comms/logic_state", 1)
+        self.running_mode_pub = self.create_publisher(String, "e_comms/running_mode", 1)
         self.throttle_pwm_pub = self.create_publisher(UInt16, "e_comms/throttle_pwm", 1)
         self.steering_pwm_pub = self.create_publisher(UInt16, "e_comms/steering_pwm", 1)
         self.speed_pub = self.create_publisher(Float32, "e_comms/kart_speed_m_per_s", 1)
@@ -126,8 +126,8 @@ class ECommsNode(Node):
         try:
             self.adcb_status = e_comms.unpack_adcb_status_message(msg_data, self.logger)
 
-            self.adcb_state_pub.publish(String(data=self.adcb_status.logic_mode))
-            self.rc_mode_pub.publish(Bool(data=self.adcb_status.rc_mode))
+            self.adcb_state_pub.publish(String(data=self.adcb_status.logic_state))
+            self.running_mode_pub.publish(String(data=self.adcb_status.running_mode))
             self.throttle_pwm_pub.publish(UInt16(data=self.adcb_status.throttle_pwm))
             self.steering_pwm_pub.publish(UInt16(data=self.adcb_status.steering_pwm))
         except Exception as e:

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -6,7 +6,7 @@ import can
 import rclpy
 from rclpy.node import Node
 from rclpy.time import Time
-from std_msgs.msg import Float32MultiArray, UInt16, Bool, String, Float32
+from std_msgs.msg import Float32MultiArray, UInt16, String, Float32
 from rclpy.impl.rcutils_logger import RcutilsLogger
 
 import autonomous_kart.nodes.e_comms.e_comms as e_comms

--- a/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/e_comms/e_comms_node.py
@@ -99,7 +99,7 @@ class ECommsNode(Node):
         self.hb_timer = self.create_timer(self.hb_tx_period_ms / 1000.0, self.can_hb_tx)
 
         # Publishers
-        self.adcb_state_pub = self.create_publisher(String, "e_comms/logic_state", 1)
+        self.logic_state_pub = self.create_publisher(String, "e_comms/logic_state", 1)
         self.running_mode_pub = self.create_publisher(String, "e_comms/running_mode", 1)
         self.throttle_pwm_pub = self.create_publisher(UInt16, "e_comms/throttle_pwm", 1)
         self.steering_pwm_pub = self.create_publisher(UInt16, "e_comms/steering_pwm", 1)
@@ -126,7 +126,7 @@ class ECommsNode(Node):
         try:
             self.adcb_status = e_comms.unpack_adcb_status_message(msg_data, self.logger)
 
-            self.adcb_state_pub.publish(String(data=self.adcb_status.logic_state))
+            self.logic_state_pub.publish(String(data=self.adcb_status.logic_state))
             self.running_mode_pub.publish(String(data=self.adcb_status.running_mode))
             self.throttle_pwm_pub.publish(UInt16(data=self.adcb_status.throttle_pwm))
             self.steering_pwm_pub.publish(UInt16(data=self.adcb_status.steering_pwm))

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -8,7 +8,7 @@ import rclpy
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from sensor_msgs.msg import Imu
-from std_msgs.msg import String, Float32MultiArray, Float32, Bool, UInt16, Empty
+from std_msgs.msg import String, Float32MultiArray, Float32,  UInt16, Empty
 
 
 class STATES(Enum):

--- a/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/master/master_node.py
@@ -73,8 +73,8 @@ class MasterNode(Node):
 
         # e_comms ADCB state snapshot
         self.e_comms_data = {
-            "adcb_state": "",
-            "rc_mode": False,
+            "logic_state": "not initialized...",
+            "running_mode": "not initialized...",
             "throttle_pwm": 0,
             "steering_pwm": 0,
         }
@@ -86,8 +86,8 @@ class MasterNode(Node):
         self.create_subscription(Float32MultiArray, "cmd_drive", self._drive_callback, 5)
 
         # e_comms ADCB telemetry
-        self.create_subscription(String, "e_comms/adcb_state", self._adcb_state_callback, 1)
-        self.create_subscription(Bool, "e_comms/rc_mode", self._rc_mode_callback, 1)
+        self.create_subscription(String, "e_comms/logic_state", self._logic_state_callback, 1)
+        self.create_subscription(String, "e_comms/running_mode", self._running_mode_callback, 1)
         self.create_subscription(UInt16, "e_comms/throttle_pwm", self._throttle_pwm_callback, 1)
         self.create_subscription(UInt16, "e_comms/steering_pwm", self._steering_pwm_callback, 1)
 
@@ -193,13 +193,13 @@ class MasterNode(Node):
             self.cmd_data["motor"] = float(msg.data[0])
             self.cmd_data["steer"] = float(msg.data[1])
 
-    def _adcb_state_callback(self, msg: String):
+    def _logic_state_callback(self, msg: String):
         with self._lock:
-            self.e_comms_data["adcb_state"] = msg.data
+            self.e_comms_data["logic_state"] = msg.data
 
-    def _rc_mode_callback(self, msg: Bool):
+    def _running_mode_callback(self, msg: String):
         with self._lock:
-            self.e_comms_data["rc_mode"] = msg.data
+            self.e_comms_data["running_mode"] = msg.data
 
     def _throttle_pwm_callback(self, msg: UInt16):
         with self._lock:

--- a/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
@@ -39,8 +39,8 @@ class MetricsNode(Node):
             "track_angles": Float32MultiArray,
             # "camera/image_raw": Image, # Note: This does not work because of invalid qos.
             # Regardless, images don't need to be saved.
-            "e_comms/adcb_state": String,
-            "e_comms/rc_mode": Bool,
+            "e_comms/logic_state": String,
+            "e_comms/running_mode": String,
             "e_comms/throttle_pwm": UInt16,
             "e_comms/steering_pwm": UInt16,
             "pathfinder_params": Float32MultiArray,

--- a/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
+++ b/src/autonomous_kart/autonomous_kart/nodes/metrics/metrics_node.py
@@ -6,7 +6,7 @@ from typing import Deque, Dict, Any
 import rclpy
 from sensor_msgs.msg import Image
 from rclpy.node import Node
-from std_msgs.msg import Float32, Float32MultiArray, Int16, String, Bool, UInt16
+from std_msgs.msg import Float32, Float32MultiArray, Int16, String,  UInt16
 from nav_msgs.msg import Odometry
 
 


### PR DESCRIPTION
- Update E_Comms and affected nodes in relation to https://github.com/EVC-Purdue/AutonomousElectrical/pull/17
- rc_mode replaced by running mode (and type changed from bool to string)
- Improved/aligned publisher, variable, and field names match with electrical code
- Frontend will need to be adjusted slightly because the E_Comms struct/JSON names changed